### PR TITLE
Closes #150

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,17 +2,18 @@
 ## Breaking Changes
 * Package now depends on R(>= 3.5.0)
 * Renamed argument `event` with `status`.
+* Renamed argument `loc_sc_params` with `dist_params`.
 * Output of probability estimators: Renamed column `characteristic` with `x`.
 * `plot_conf()`: Switched position of arguments distribution and direction.
 * `rank_regression()`, `ml_estimation()`: Removed `details` argument.
-* `rank_regression()`, `ml_estimation()`: Renamed output: `loc_sc_coefficients` -> `loc_sc_params`, `loc_sc_vcov` -> `loc_sc_varcov`
-* `plot_pop()`: Added argument `tol` to restrict the range of failure probabilities. Removed argument `color`. Renamed argument `params` to `loc_sc_params_tbl`, which only supports location and scale parameters (also for `distribution = "weibull"`). Changed behaviour of `loc_sc_params_tbl`: A tibble is now recommended instead of a vector.
+* `rank_regression()`, `ml_estimation()`: Renamed output: `loc_sc_vcov` -> `loc_sc_varcov`. Removed `loc_sc_params` from output. Added `shape_scale_coefficients` if `distribution` is `"weibull"` or `"weibull3"`.
+* `plot_pop()`: Added argument `tol` to restrict the range of failure probabilities. Removed argument `color`. Renamed argument `params` to `dist_params_tbl`, which only supports location and scale parameters (also for `distribution = "weibull"`). Changed behaviour of `dist_params_tbl`: A tibble is now recommended instead of a vector.
 * `plot_prob_mix`: Removed default value `NULL` for argument `mix_output`.
 * `dist_mileage()`: Removed `status` argument and switched argument positions of `x` and `mileage`  -> (`mileage`, `x`, `distribution`). Argument `x` was renamed to `time`.
 * `mcs_mileage()`: Removed arguments `seed` and `details`, incorporated new default argument `id`. For now, the argument `status` is optional. Argument positions of `x` and `mileage` are switched -> (`mileage`, `x`). Argument `x` was renamed to `time`. 
 * `mcs_delay_register()`, `mcs_delay_report()`, `mcs_delays()`: Argument `seed` and element `int_seed` of the output list have been removed. For reproducibility use `set.seed()` before calling one of these functions. Argument `x` was renamed to `time`.  
 * `confint_betabinom.default()` and `confint_fisher.default()`: New argument `b_lives`.
-* `loglik_function()`: Renamed argument `pars` with `loc_sc_params`. 
+* `loglik_function()`: Renamed argument `pars` with `dist_params`. 
 * `mixmod_em()`: Removed argument `post`.
 
 ## New Features

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 * Package now depends on R(>= 3.5.0)
 * Renamed argument `event` with `status`.
 * Output of probability estimators: Renamed column `characteristic` with `x`.
-* `plot_conf()`: Switched arguments distribution and direction.
+* `plot_conf()`: Switched position of arguments distribution and direction.
 * `rank_regression()`, `ml_estimation()`: Removed `details` argument.
 * `rank_regression()`, `ml_estimation()`: Renamed output: `loc_sc_coefficients` -> `loc_sc_params`, `loc_sc_vcov` -> `loc_sc_varcov`
 * `plot_pop()`: Added argument `tol` to restrict the range of failure probabilities. Removed argument `color`. Renamed argument `params` to `loc_sc_params_tbl`, which only supports location and scale parameters (also for `distribution = "weibull"`). Changed behaviour of `loc_sc_params_tbl`: A tibble is now recommended instead of a vector.

--- a/R/confidence_intervals.R
+++ b/R/confidence_intervals.R
@@ -164,6 +164,9 @@ confint_betabinom.model_estimation <- function(
                                  direction = c("y", "x"),
                                  ...
 ) {
+  bounds <- match.arg(bounds)
+  direction <- match.arg(direction)
+
   confint_betabinom_(
     model_estimation = x,
     b_lives = b_lives,

--- a/R/ml_estimation.R
+++ b/R/ml_estimation.R
@@ -21,31 +21,8 @@
 #' @param conf_level Confidence level of the interval.
 #' @template dots
 #'
-#' @return Returns a list with the classes \code{"ml_estimation"} and
-#'   \code{"model_estimation"} containing the following elements:
-#'   \itemize{
-#'     \item \code{coefficients} : If \code{distribution} is \code{"weibull"}, the
-#'       estimated scale (\eqn{\eta}) and shape (\eqn{\beta}) parameters are provided
-#'       (and additionally the threshold parameter \eqn{\gamma} if \code{distribution}
-#'       is \code{"weibull3"}). For any other distribution, \code{coefficients} is
-#'       identical to \code{loc_sc_params}.
-#'     \item \code{confint} : Only included if \code{distribution} is \code{"weibull"}
-#'       or \code{"weibull3"}. Confidence intervals for \eqn{\eta} and \eqn{\beta}
-#'       (and \eqn{\gamma} if \code{distribution} is \code{"weibull3"}).
-#'     \item \code{loc_sc_params} : Estimated (log-)location-scale parameters.
-#'       Threshold parameter is included if \code{distribution} is \code{"weibull3"},
-#'       \code{"lognormal3"} or \code{"loglogistic3"}.
-#'     \item \code{loc_sc_confint} : Confidence intervals the (log-)location-scale
-#'       parameters.
-#'     \item \code{loc_sc_varcov} : Estimated variance-covariance matrix for the
-#'       (log-)location-scale parameters.
-#'     \item \code{logL} : The log-likelihood value.
-#'     \item \code{aic} : Akaike Information Criterion.
-#'     \item \code{bic} : Bayesian Information Criterion.
-#'     \item \code{data} : A tibble with class \code{"reliability_data"} returned
-#'       by \code{\link{reliability_data}}.
-#'     \item \code{distribution} : Specified distribution.
-#'   }
+#' @template return-ml-estimation
+#' @templateVar data A tibble with class \code{"reliability_data"} returned from \code{\link{reliability_data}}.
 #'
 #' @encoding UTF-8
 #'
@@ -127,30 +104,7 @@ ml_estimation.reliability_data <- function(x,
 #' @param status A vector of binary data (0 or 1) indicating whether unit \emph{i}
 #'   is a right censored observation (= 0) or a failure (= 1).
 #'
-#' @return Returns a list with the classes \code{"ml_estimation"} and
-#'   \code{"model_estimation"} containing the following elements:
-#'   \itemize{
-#'     \item \code{coefficients} : If \code{distribution} is \code{"weibull"}, the
-#'       estimated scale (\eqn{\eta}) and shape (\eqn{\beta}) parameters are provided
-#'       (and additionally the threshold parameter \eqn{\gamma} if \code{distribution}
-#'       is \code{"weibull3"}). For any other distribution, \code{coefficients} is
-#'       identical to \code{loc_sc_params}.
-#'     \item \code{confint} : Only included if \code{distribution} is \code{"weibull"}
-#'       or \code{"weibull3"}. Confidence intervals for \eqn{\eta} and \eqn{\beta}
-#'       (and \eqn{\gamma} if \code{distribution} is \code{"weibull3"}).
-#'     \item \code{loc_sc_params} : Estimated (log-)location-scale parameters.
-#'       Threshold parameter is included if \code{distribution} is \code{"weibull3"},
-#'       \code{"lognormal3"} or \code{"loglogistic3"}.
-#'     \item \code{loc_sc_confint} : Confidence intervals the (log-)location-scale
-#'       parameters.
-#'     \item \code{loc_sc_varcov} : Estimated variance-covariance matrix for the
-#'       (log-)location-scale parameters.
-#'     \item \code{logL} : The log-likelihood value.
-#'     \item \code{aic} : Akaike Information Criterion.
-#'     \item \code{bic} : Bayesian Information Criterion.
-#'     \item \code{data} : A tibble with columns \code{x} and \code{status}.
-#'     \item \code{distribution} : Specified distribution.
-#'   }
+#'
 #'
 #' @seealso \code{\link{ml_estimation}}
 #'
@@ -252,9 +206,9 @@ ml_estimation_ <- function(data,
       rownames(conf_ints) <- names(estimates)
 
       ml_output <- list(
-        coefficients = estimates,
+        coefficients = estimates_loc_sc,
+        shape_scale_coefficients = estimates,
         confint = conf_ints,
-        loc_sc_params = estimates_loc_sc,
         loc_sc_confint = conf_ints_loc_sc,
         loc_sc_varcov = vcov_loc_sc, logL = -ml$min,
         aic = -2 * (-ml$min) + 2 * length(estimates_loc_sc),
@@ -263,7 +217,6 @@ ml_estimation_ <- function(data,
     } else {
       ml_output <- list(
         coefficients = estimates_loc_sc,
-        loc_sc_params = estimates_loc_sc,
         loc_sc_confint = conf_ints_loc_sc,
         loc_sc_varcov = vcov_loc_sc, logL = -ml$min,
         aic = -2 * (-ml$min) + 2 * length(estimates_loc_sc),
@@ -355,9 +308,9 @@ ml_estimation_ <- function(data,
       rownames(conf_ints) <- names(estimates)
 
       ml_output <- list(
-        coefficients = estimates,
+        coefficients = estimates_loc_sc,
+        shape_scale_coefficients = estimates,
         confint = conf_ints,
-        loc_sc_params = estimates_loc_sc,
         loc_sc_confint = conf_ints_loc_sc,
         loc_sc_varcov = vcov_loc_sc, logL = ml$value,
         aic = -2 * (ml$value) + 2 * length(estimates_loc_sc),
@@ -367,7 +320,6 @@ ml_estimation_ <- function(data,
     } else {
       ml_output <- list(
         coefficients = estimates_loc_sc,
-        loc_sc_params = estimates_loc_sc,
         loc_sc_confint = conf_ints_loc_sc,
         loc_sc_varcov = vcov_loc_sc, logL = ml$value,
         aic = -2 * (ml$value) + 2 * length(estimates_loc_sc),
@@ -435,7 +387,6 @@ ml_estimation_ <- function(data,
 
     ml_output <- list(
       coefficients = estimates_loc_sc,
-      loc_sc_params = estimates_loc_sc,
       loc_sc_confint = conf_ints_loc_sc,
       loc_sc_varcov = vcov_loc_sc, logL = ml$value,
       aic = -2 * (ml$value) + 2 * length(estimates_loc_sc),
@@ -592,7 +543,7 @@ loglik_profiling_ <- function(x,
 #'
 #' @return
 #' Returns the log-likelihood value for the data with respect to the parameters
-#' given in \code{loc_sc_params}.
+#' given in \code{dist_params}.
 #'
 #' @encoding UTF-8
 #'
@@ -608,7 +559,7 @@ loglik_profiling_ <- function(x,
 #' loglik_weib <- loglik_function(
 #'   x = cycles,
 #'   status = status,
-#'   loc_sc_params = c(5.29, 0.33),
+#'   dist_params = c(5.29, 0.33),
 #'   distribution = "weibull"
 #' )
 #'
@@ -616,7 +567,7 @@ loglik_profiling_ <- function(x,
 #' loglik_weib3 <- loglik_function(
 #'   x = cycles,
 #'   status = status,
-#'   loc_sc_params = c(4.54, 0.76, 92.99),
+#'   dist_params = c(4.54, 0.76, 92.99),
 #'   distribution = "weibull3"
 #' )
 #'
@@ -624,7 +575,7 @@ loglik_profiling_ <- function(x,
 loglik_function <- function(x,
                             status,
                             wts = rep(1, length(x)),
-                            loc_sc_params,
+                            dist_params,
                             distribution = c(
                               "weibull", "lognormal", "loglogistic",
                               "normal", "logistic", "sev",
@@ -635,9 +586,9 @@ loglik_function <- function(x,
   distribution <- match.arg(distribution)
 
   d <- status
-  mu <- loc_sc_params[1]
-  sig <- loc_sc_params[2]
-  thres <- loc_sc_params[3]
+  mu <- dist_params[1]
+  sig <- dist_params[2]
+  thres <- dist_params[3]
 
   if (is.na(thres)) {
     # Log- and Location-Scale Models:

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -849,7 +849,7 @@ plot_mod.mixmod_regression <- function(p_obj, x, title_trace = "Fit", ...) {
   }
 
   tbl_pred <- purrr::map2_dfr(x, seq_along(x), function(model_estimation, index) {
-    method <- if (purrr::is_null(model_estimation$data$method)) {
+    method <- if (!tibble::has_name(model_estimation$data, "method")) {
       # Case mixmod_em (plot_mod.mixmod_em calls this method internally)
       as.character(index)
     } else {

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -778,7 +778,7 @@ plot_mod.model_estimation <- function(p_obj, x, title_trace = "Fit", ...) {
   plot_mod.default(
     p_obj = p_obj,
     x = range(failed_data$x),
-    loc_sc_params = x$loc_sc_params,
+    dist_params = x$coefficients,
     distribution = x$distribution,
     title_trace = title_trace
   )
@@ -812,7 +812,7 @@ plot_mod.model_estimation_list <- function(p_obj, x, title_trace = "Fit", ...) {
 
     plot_mod_helper(
       x = range(failed_data$x),
-      loc_sc_params = model_estimation$loc_sc_params,
+      dist_params = model_estimation$coefficients,
       distribution = model_estimation$distribution,
       method = method
     )
@@ -948,7 +948,7 @@ plot_mod.mixmod_em <- function(p_obj, x, title_trace = "Fit", ...) {
 #' @inherit plot_mod description return references
 #'
 #' @param x A numeric vector containing the x-coordinates of the regression line.
-#' @param loc_sc_params A (named) numeric vector of estimated location
+#' @param dist_params A (named) numeric vector of estimated location
 #'   and scale parameters for a specified distribution. The order of
 #'   elements is important. First entry needs to be the location
 #'   parameter \eqn{\mu} and the second element needs to be the scale
@@ -998,7 +998,7 @@ plot_mod.mixmod_em <- function(p_obj, x, title_trace = "Fit", ...) {
 #' plot_reg_weibull <- plot_mod(
 #'   p_obj = plot_weibull,
 #'   x = tbl_john$x,
-#'   loc_sc_params = rr$loc_sc_params,
+#'   dist_params = rr$coefficients,
 #'   distribution = "weibull3",
 #'   title_trace = "Estimated Weibull CDF"
 #' )
@@ -1029,7 +1029,7 @@ plot_mod.mixmod_em <- function(p_obj, x, title_trace = "Fit", ...) {
 #' plot_reg_lognormal <- plot_mod(
 #'   p_obj = plot_lognormal,
 #'   x = tbl_john$x,
-#'   loc_sc_params = rr_ln$loc_sc_params,
+#'   dist_params = rr_ln$coefficients,
 #'   distribution = "lognormal3",
 #'   title_trace = "Estimated Lognormal CDF"
 #' )
@@ -1038,7 +1038,7 @@ plot_mod.mixmod_em <- function(p_obj, x, title_trace = "Fit", ...) {
 #'
 plot_mod.default <- function(p_obj,
                              x,
-                             loc_sc_params,
+                             dist_params,
                              distribution = c(
                               "weibull", "lognormal", "loglogistic", "normal",
                               "logistic", "sev", "weibull3", "lognormal3",
@@ -1063,7 +1063,7 @@ plot_mod.default <- function(p_obj,
   }
 
   tbl_pred <- plot_mod_helper(
-    x, loc_sc_params, distribution
+    x, dist_params, distribution
   )
 
   plot_mod_fun <- if (plot_method == "plotly") plot_mod_plotly else
@@ -1334,7 +1334,7 @@ plot_conf.confint <- function(p_obj,
     plot_mod_helper(
       # Take x coordinates from confint. This guarantees considering of b lives
       x = x$x,
-      loc_sc_params = model_estimation$loc_sc_params,
+      dist_params = model_estimation$coefficients,
       distribution = model_estimation$distribution,
       method = method
     )
@@ -1422,7 +1422,7 @@ plot_conf.confint <- function(p_obj,
 #' conf_betabin <- confint_betabinom(
 #'   x = tbl_john$x,
 #'   status = tbl_john$status,
-#'   loc_sc_params = rr$loc_sc_params,
+#'   dist_params = rr$coefficients,
 #'   distribution = "weibull3",
 #'   bounds = "two_sided",
 #'   conf_level = 0.95,
@@ -1445,7 +1445,7 @@ plot_conf.confint <- function(p_obj,
 #'   p_obj = plot_weibull,
 #'   x = conf_betabin$x,
 #'   y = conf_betabin$prob,
-#'   loc_sc_params = rr$loc_sc_params,
+#'   dist_params = rr$coefficients,
 #'   distribution = "weibull3",
 #'   title_trace = "Estimated Weibull CDF"
 #' )
@@ -1471,7 +1471,7 @@ plot_conf.confint <- function(p_obj,
 #' conf_betabin_ln <- confint_betabinom(
 #'   x = tbl_john$x,
 #'   status = tbl_john$status,
-#'   loc_sc_params = rr_ln$loc_sc_params,
+#'   dist_params = rr_ln$coefficients,
 #'   distribution = "lognormal3",
 #'   bounds = "two_sided",
 #'   conf_level = 0.95,
@@ -1494,7 +1494,7 @@ plot_conf.confint <- function(p_obj,
 #'   p_obj = plot_lognormal,
 #'   x = conf_betabin_ln$x,
 #'   y = conf_betabin_ln$prob,
-#'   loc_sc_params = rr_ln$loc_sc_params,
+#'   dist_params = rr_ln$coefficients,
 #'   distribution = "lognormal3",
 #'   title_trace = "Estimated Lognormal CDF"
 #' )
@@ -1565,7 +1565,7 @@ plot_conf.default <- function(
 #' This function adds one or multiple linearized CDFs to an existing plot grid.
 #'
 #' @details
-#' \code{loc_sc_params_tbl} is a data.frame with two or three columns. For
+#' \code{dist_params_tbl} is a data.frame with two or three columns. For
 #' location-scale distributions the first column contains the location parameter
 #' and the second column contains the scale parameter. For three-parametric
 #' distributions the third column contains the threshold parameter.
@@ -1580,12 +1580,12 @@ plot_conf.default <- function(
 #'   between \code{x[1]} and \code{x[2]} is created. This sequence is equidistant
 #'   with respect to the scale of the x axis. If \code{length(x) > 2} the elements
 #'   of \code{x} are the x coordinates of the population line.
-#' @param loc_sc_params_tbl A tibble. See 'Details'.
+#' @param dist_params_tbl A tibble. See 'Details'.
 #' @param distribution Supposed distribution of the random variable. In the
 #'   context of this function \code{"weibull"}, \code{"lognormal"} and
 #'   \code{"loglogistic"} stand for the two- \strong{and} the three-parametric
 #'   version of the respective distribution. The distinction is made via
-#'   \code{loc_sc_params_tbl}.
+#'   \code{dist_params_tbl}.
 #' @param tol The failure probability is restricted to the interval
 #'   \eqn{[tol, 1 - tol]}. The default value is in accordance with the decimal
 #'   places shown in the hover for \code{plot_method = "plotly"}.
@@ -1610,7 +1610,7 @@ plot_conf.default <- function(
 #' pop_weibull <- plot_pop(
 #'   p_obj = grid_weibull,
 #'   x = range(x),
-#'   loc_sc_params_tbl = c(log(20000), 1),
+#'   dist_params_tbl = c(log(20000), 1),
 #'   distribution = "weibull",
 #'   title_trace = "Population"
 #' )
@@ -1621,7 +1621,7 @@ plot_conf.default <- function(
 #' pop_weibull_2 <- plot_pop(
 #'   p_obj = NULL,
 #'   x = x2,
-#'   loc_sc_params_tbl = c(log(20000 - 5000), 1, 5000),
+#'   dist_params_tbl = c(log(20000 - 5000), 1, 5000),
 #'   distribution = "weibull",
 #'   title_trace = "Population"
 #' )
@@ -1630,7 +1630,7 @@ plot_conf.default <- function(
 #' pop_weibull_3 <- plot_pop(
 #'   p_obj = NULL,
 #'   x = x,
-#'   loc_sc_params_tbl = tibble(
+#'   dist_params_tbl = tibble(
 #'     p_1 = c(log(20000), log(20000), log(20000)),
 #'     p_2 = c(1, 1.5, 2)
 #'     ),
@@ -1643,7 +1643,7 @@ plot_conf.default <- function(
 #' pop_weibull_4 <- plot_pop(
 #'   p_obj = NULL,
 #'   x = x,
-#'   loc_sc_params_tbl = tibble(
+#'   dist_params_tbl = tibble(
 #'     param_1 = c(log(20000), log(20000)),
 #'     param_2 = c(1, 1),
 #'     param_3 = c(NA, 5)
@@ -1652,7 +1652,7 @@ plot_conf.default <- function(
 #'
 #' @export
 plot_pop <- function(
-  p_obj = NULL, x, loc_sc_params_tbl,
+  p_obj = NULL, x, dist_params_tbl,
   distribution = c(
     "weibull", "lognormal", "loglogistic", "normal", "logistic", "sev"
   ),
@@ -1685,25 +1685,25 @@ plot_pop <- function(
     }
   }
 
-  # Support vector instead of tibble for ease of use in loc_sc_params_tbl
-  if (!inherits(loc_sc_params_tbl, "data.frame")) {
-    loc_sc_params_tbl <- tibble::tibble(
-      loc = loc_sc_params_tbl[1],
-      sc = loc_sc_params_tbl[2],
+  # Support vector instead of tibble for ease of use in dist_params_tbl
+  if (!inherits(dist_params_tbl, "data.frame")) {
+    dist_params_tbl <- tibble::tibble(
+      loc = dist_params_tbl[1],
+      sc = dist_params_tbl[2],
       # NA if length 2
-      thres = loc_sc_params_tbl[3]
+      thres = dist_params_tbl[3]
     )
   }
 
   # Add thres column if not present
-  if (ncol(loc_sc_params_tbl) == 2) {
-    loc_sc_params_tbl$thres <- NA_real_
+  if (ncol(dist_params_tbl) == 2) {
+    dist_params_tbl$thres <- NA_real_
   }
 
   # Ensure correct naming
-  names(loc_sc_params_tbl) <- c("loc", "sc", "thres")
+  names(dist_params_tbl) <- c("loc", "sc", "thres")
 
-  tbl_pop <- plot_pop_helper(x, loc_sc_params_tbl, distribution, tol)
+  tbl_pop <- plot_pop_helper(x, dist_params_tbl, distribution, tol)
 
   plot_pop_fun <- if (plot_method == "plotly") plot_pop_plotly else
     plot_pop_ggplot2

--- a/R/plot_helpers.R
+++ b/R/plot_helpers.R
@@ -69,13 +69,11 @@ plot_prob_helper <- function(
   }
   tbl$q <- q
 
-  if (!hasName(tbl, "group")) tbl$group <- "null"
-
   tbl
 }
 
 plot_mod_helper <- function(
-  x, loc_sc_params, distribution, method = "mod_null"
+  x, loc_sc_params, distribution, method = NA_character_
 ) {
   if (length(x) == 2) {
     if (distribution %in% c("weibull", "lognormal", "loglogistic")) {
@@ -139,7 +137,7 @@ plot_mod_helper <- function(
       param_val = list(param_val),
       param_label = list(param_label),
       method = method,
-      group = "_null",
+      group = NA_character_,
       q = q
     )
 }
@@ -244,7 +242,7 @@ plot_conf_helper <- function(tbl_mod, x, y, direction, distribution) {
   }
 
   tbl_p <- dplyr::group_by(tbl_p, bound)
-  tbl_p$method <- "conf_null"
+  tbl_p$method <- NA_character_
 
   return(tbl_p)
 }

--- a/R/plot_helpers.R
+++ b/R/plot_helpers.R
@@ -73,7 +73,7 @@ plot_prob_helper <- function(
 }
 
 plot_mod_helper <- function(
-  x, loc_sc_params, distribution, method = NA_character_
+  x, dist_params, distribution, method = NA_character_
 ) {
   if (length(x) == 2) {
     if (distribution %in% c("weibull", "lognormal", "loglogistic")) {
@@ -100,7 +100,7 @@ plot_mod_helper <- function(
 
   y_p <- predict_prob(
     q = x_p,
-    loc_sc_params = loc_sc_params,
+    dist_params = dist_params,
     distribution = distribution
   )
 
@@ -123,10 +123,10 @@ plot_mod_helper <- function(
 
   # preparation of plotly hovers:
   ## raises problems if one-parameter distributions like exponential will be implemented!
-  param_val <- format(loc_sc_params, digits = 3)
+  param_val <- format(dist_params, digits = 3)
   # Enforce length 3
-  if (length(loc_sc_params) == 2) param_val <- c(param_val, NA)
-  param_label <- if (length(loc_sc_params) == 2) {
+  if (length(dist_params) == 2) param_val <- c(param_val, NA)
+  param_label <- if (length(dist_params) == 2) {
     c("\u03BC:", "\u03C3:", NA)
   } else {
     c("\u03BC:", "\u03C3:", "\u03B3:")
@@ -153,12 +153,12 @@ plot_mod_mix_helper <- function(model_estimation, method, group) {
   x_p <- seq(x_min, x_max, length.out = 200)
   y_p <- predict_prob(
     q = x_p,
-    loc_sc_params = model_estimation$loc_sc_params,
+    dist_params = model_estimation$coefficients,
     distribution = distribution
   )
 
-  param_1 <- format(model_estimation$loc_sc_params[[1]], digits = 3)
-  param_2 <- format(model_estimation$loc_sc_params[[2]], digits = 3)
+  param_1 <- format(model_estimation$coefficients[[1]], digits = 3)
+  param_2 <- format(model_estimation$coefficients[[2]], digits = 3)
   label_1 <- "\u03BC:"
   label_2 <- "\u03C3:"
 
@@ -247,27 +247,27 @@ plot_conf_helper <- function(tbl_mod, x, y, direction, distribution) {
   return(tbl_p)
 }
 
-plot_pop_helper <- function(x, loc_sc_params_tbl, distribution, tol = 1e-6) {
+plot_pop_helper <- function(x, dist_params_tbl, distribution, tol = 1e-6) {
   x_s <- if (length(x) == 2) {
     10 ^ seq(log10(x[1]), log10(x[2]), length.out = 200)
   } else {
     x
   }
 
-  tbl_pop <- loc_sc_params_tbl %>%
+  tbl_pop <- dist_params_tbl %>%
     dplyr::mutate(group = as.character(dplyr::row_number()))
   # column x_y is list column that contains a tibble each
   tbl_pop$x_y <- purrr::pmap(
-    loc_sc_params_tbl,
+    dist_params_tbl,
     x_s = x_s,
     distribution = distribution,
     function(loc, sc, thres = NA, x_s, distribution) {
       # Replace NA with NULL, so that thres is ignored in c()
       if (is.na(thres)) thres <- NULL
 
-      loc_sc_params <- c(loc, sc, thres)
+      dist_params <- c(loc, sc, thres)
 
-      if (length(loc_sc_params) == 3) {
+      if (length(dist_params) == 3) {
         # Case three-parametric distribution
         distribution <- paste0(distribution, "3")
       }
@@ -276,7 +276,7 @@ plot_pop_helper <- function(x, loc_sc_params_tbl, distribution, tol = 1e-6) {
         x_s = x_s,
         y_s = predict_prob(
           q = x_s,
-          loc_sc_params = loc_sc_params,
+          dist_params = dist_params,
           distribution = distribution
         )
       )

--- a/R/predict.R
+++ b/R/predict.R
@@ -9,7 +9,7 @@
 #' of the chosen model are determined.
 #'
 #' @param p A numeric vector of probabilities.
-#' @param loc_sc_params A (named) numeric vector of (log-)location-scale parameters
+#' @param dist_params A (named) numeric vector of (log-)location-scale parameters
 #'   in the order of location (\eqn{\mu}) and scale (\eqn{\sigma}). If a
 #'   three-parametric model is selected, the threshold parameter (\eqn{\gamma})
 #'   has to be the third element.
@@ -21,20 +21,20 @@
 #' # Example 1 - Predicted quantiles for a two-parameter weibull distribution:
 #' quants_weib2 <- predict_quantile(
 #'   p = c(0.01, 0.1, 0.5),
-#'   loc_sc_params = c(5, 0.5),
+#'   dist_params = c(5, 0.5),
 #'   distribution = "weibull"
 #' )
 #'
 #' # Example 2 - Predicted quantiles for a three-parameter weibull distribution:
 #' quants_weib3 <- predict_quantile(
 #'   p = c(0.01, 0.1, 0.5),
-#'   loc_sc_params = c(5, 0.5, 10),
+#'   dist_params = c(5, 0.5, 10),
 #'   distribution = "weibull3"
 #' )
 #'
 #' @export
 predict_quantile <- function(p,
-                             loc_sc_params,
+                             dist_params,
                              distribution = c(
                                "weibull", "lognormal", "loglogistic",
                                "normal", "logistic", "sev",
@@ -46,36 +46,36 @@ predict_quantile <- function(p,
 
   # Log-Location-Scale Distributions:
   if (distribution == "weibull") {
-    quantiles <- exp(SPREDA::qsev(p) * loc_sc_params[[2]] + loc_sc_params[[1]])
+    quantiles <- exp(SPREDA::qsev(p) * dist_params[[2]] + dist_params[[1]])
   }
   if (distribution == "lognormal") {
-    quantiles <- exp(stats::qnorm(p) * loc_sc_params[[2]] + loc_sc_params[[1]])
+    quantiles <- exp(stats::qnorm(p) * dist_params[[2]] + dist_params[[1]])
   }
   if (distribution == "loglogistic") {
-    quantiles <- exp(stats::qlogis(p) * loc_sc_params[[2]] + loc_sc_params[[1]])
+    quantiles <- exp(stats::qlogis(p) * dist_params[[2]] + dist_params[[1]])
   }
   # Log-Location-Scale Distributions with Threshold:
   if (distribution == "weibull3") {
-    quantiles <- exp(SPREDA::qsev(p) * loc_sc_params[[2]] + loc_sc_params[[1]]) +
-      loc_sc_params[[3]]
+    quantiles <- exp(SPREDA::qsev(p) * dist_params[[2]] + dist_params[[1]]) +
+      dist_params[[3]]
   }
   if (distribution == "lognormal3") {
-    quantiles <- exp(stats::qnorm(p) * loc_sc_params[[2]] + loc_sc_params[[1]]) +
-      loc_sc_params[[3]]
+    quantiles <- exp(stats::qnorm(p) * dist_params[[2]] + dist_params[[1]]) +
+      dist_params[[3]]
   }
   if (distribution == "loglogistic3") {
-    quantiles <- exp(stats::qlogis(p) * loc_sc_params[[2]] + loc_sc_params[[1]]) +
-      loc_sc_params[[3]]
+    quantiles <- exp(stats::qlogis(p) * dist_params[[2]] + dist_params[[1]]) +
+      dist_params[[3]]
   }
   # Location-Scale Distributions:
   if (distribution == "sev") {
-    quantiles <- SPREDA::qsev(p) * loc_sc_params[[2]] + loc_sc_params[[1]]
+    quantiles <- SPREDA::qsev(p) * dist_params[[2]] + dist_params[[1]]
   }
   if (distribution == "normal") {
-    quantiles <- stats::qnorm(p) * loc_sc_params[[2]] + loc_sc_params[[1]]
+    quantiles <- stats::qnorm(p) * dist_params[[2]] + dist_params[[1]]
   }
   if (distribution == "logistic") {
-    quantiles <- stats::qlogis(p) * loc_sc_params[[2]] + loc_sc_params[[1]]
+    quantiles <- stats::qlogis(p) * dist_params[[2]] + dist_params[[1]]
   }
 
   return(quantiles)
@@ -103,20 +103,20 @@ predict_quantile <- function(p,
 #' # Example 1 - Predicted probabilities for a two-parameter weibull distribution:
 #' probs_weib2 <- predict_prob(
 #'   q = c(15, 48, 124),
-#'   loc_sc_params = c(5, 0.5),
+#'   dist_params = c(5, 0.5),
 #'   distribution = "weibull"
 #' )
 #'
 #' # Example 2 - Predicted quantiles for a three-parameter weibull distribution:
 #' probs_weib3 <- predict_prob(
 #'   q = c(25, 58, 134),
-#'   loc_sc_params = c(5, 0.5, 10),
+#'   dist_params = c(5, 0.5, 10),
 #'   distribution = "weibull3"
 #' )
 #'
 #' @export
 predict_prob <- function(q,
-                         loc_sc_params,
+                         dist_params,
                          distribution = c(
                            "weibull", "lognormal", "loglogistic",
                            "normal", "logistic", "sev",
@@ -129,49 +129,49 @@ predict_prob <- function(q,
   # Log-Location-Scale Distributions:
   if (distribution == "weibull") {
     # Standardize:
-    z <- (log(q) - loc_sc_params[[1]]) / loc_sc_params[[2]]
+    z <- (log(q) - dist_params[[1]]) / dist_params[[2]]
     cdf <- SPREDA::psev(z)
   }
   if (distribution == "lognormal") {
     # Standardize:
-    z <- (log(q) - loc_sc_params[[1]]) / loc_sc_params[[2]]
+    z <- (log(q) - dist_params[[1]]) / dist_params[[2]]
     cdf <- stats::pnorm(z)
   }
   if (distribution == "loglogistic") {
     # Standardize:
-    z <- (log(q) - loc_sc_params[[1]]) / loc_sc_params[[2]]
+    z <- (log(q) - dist_params[[1]]) / dist_params[[2]]
     cdf <- stats::plogis(z)
   }
   # Log-Location-Scale Distributions with Threshold:
   if (distribution == "weibull3") {
     # Standardize:
-    z <- (log(q - loc_sc_params[[3]]) - loc_sc_params[[1]]) / loc_sc_params[[2]]
+    z <- (log(q - dist_params[[3]]) - dist_params[[1]]) / dist_params[[2]]
     cdf <- SPREDA::psev(z)
   }
   if (distribution == "lognormal3") {
     # Standardize:
-    z <- (log(q - loc_sc_params[[3]]) - loc_sc_params[[1]]) / loc_sc_params[[2]]
+    z <- (log(q - dist_params[[3]]) - dist_params[[1]]) / dist_params[[2]]
     cdf <- stats::pnorm(z)
   }
   if (distribution == "loglogistic3") {
     # Standardize:
-    z <- (log(q - loc_sc_params[[3]]) - loc_sc_params[[1]]) / loc_sc_params[[2]]
+    z <- (log(q - dist_params[[3]]) - dist_params[[1]]) / dist_params[[2]]
     cdf <- stats::plogis(z)
   }
   # Location-Scale Distributions:
   if (distribution == "sev") {
     # Standardize:
-    z <- (q - loc_sc_params[[1]]) / loc_sc_params[[2]]
+    z <- (q - dist_params[[1]]) / dist_params[[2]]
     cdf <- SPREDA::psev(z)
   }
   if (distribution == "normal") {
     # Standardize:
-    z <- (q - loc_sc_params[[1]]) / loc_sc_params[[2]]
+    z <- (q - dist_params[[1]]) / dist_params[[2]]
     cdf <- stats::pnorm(z)
   }
   if (distribution == "logistic") {
     # Standardize:
-    z <- (q - loc_sc_params[[1]]) / loc_sc_params[[2]]
+    z <- (q - dist_params[[1]]) / dist_params[[2]]
     cdf <- stats::plogis(z)
   }
 

--- a/R/probability_estimators.R
+++ b/R/probability_estimators.R
@@ -175,6 +175,8 @@ estimate_cdf.reliability_data <- function(x,
 #' @param status A vector of binary data (0 or 1) indicating whether unit \emph{i}
 #'   is a right censored observation (= 0) or a failure (= 1).
 #' @param id A vector for the identification of every unit. Default is \code{NULL}.
+#' @param method Method used for the estimation of failure probabilities. See
+#'   'Details'.
 #'
 #' @inheritSection estimate_cdf Options
 #'
@@ -192,15 +194,9 @@ estimate_cdf.reliability_data <- function(x,
 #'   methods = "johnson"
 #' )
 #'
-#' # Example 2 - Multiple methods:
-#' prob_tbl_2 <- estimate_cdf(
-#'   x = cycles,
-#'   status = status,
-#'   methods = c("johnson", "kaplan", "nelson")
-#' )
 #'
-#' # Example 3 - Method 'mr' with options:
-#' prob_tbl_3 <- estimate_cdf(
+#' # Example 2 - Method 'mr' with options:
+#' prob_tbl_2 <- estimate_cdf(
 #'   x = cycles,
 #'   status = status,
 #'   methods = "mr",
@@ -210,21 +206,11 @@ estimate_cdf.reliability_data <- function(x,
 #'   )
 #' )
 #'
-#' # Example 4 - Multiple methods and option for 'mr':
-#' prob_tbl_4 <- estimate_cdf(
-#'   x = cycles,
-#'   status = status,
-#'   methods = c("mr", "johnson"),
-#'   options = list(
-#'     mr_ties.method = "max"
-#'   )
-#' )
-#'
 #' @export
 estimate_cdf.default <- function(x,
                                  status,
                                  id = NULL,
-                                 methods = c(
+                                 method = c(
                                    "mr", "johnson", "kaplan", "nelson"
                                  ),
                                  options = list(),
@@ -237,15 +223,11 @@ estimate_cdf.default <- function(x,
 
   data <- reliability_data(x = x, status = status, id = id)
 
-  methods <- if (missing(methods)) {
-    "mr"
-  } else {
-    unique(match.arg(methods, several.ok = TRUE))
-  }
+  method = match.arg(method)
 
   estimate_cdf.reliability_data(
     x = data,
-    methods = methods,
+    methods = method,
     options = options
   )
 }

--- a/R/rank_regression.R
+++ b/R/rank_regression.R
@@ -33,34 +33,12 @@
 #'   \code{"weibull"} this must be one of \code{0.9}, \code{0.95} or \code{0.99}.
 #' @template dots
 #'
-#' @return Returns a list with the classes \code{"rank_regression"} and
-#'   \code{"model_estimation"} containing the following elements:
-#'   \itemize{
-#'     \item \code{coefficients} : If \code{distribution} is \code{"weibull"}, the
-#'       estimated scale (\eqn{\eta}) and shape (\eqn{\beta}) parameters are provided
-#'       (and additionally the threshold parameter \eqn{\gamma} if \code{distribution}
-#'       is \code{"weibull3"}). For any other distribution, \code{coefficients} is
-#'       identical to \code{loc_sc_params}.
-#'     \item \code{confint} : Only included if \code{distribution} is \code{"weibull"}
-#'       or \code{"weibull3"}. Approximated confidence intervals for \eqn{\eta} and
-#'       \eqn{\beta} (and \eqn{\gamma} if \code{distribution} is \code{"weibull3"}).
-#'     \item \code{loc_sc_params} : Estimated (log-)location-scale parameters.
-#'       Threshold parameter is included if \code{distribution} is \code{"weibull3"},
-#'       \code{"lognormal3"} or \code{"loglogistic3"}.
-#'     \item \code{loc_sc_confint} : Confidence intervals for (log-)location-scale
-#'       parameters. If distribution is \code{"lognormal3"} or \code{"loglogistic3"}
-#'       a confidence interval for the threshold parameter is not computed.
-#'     \item \code{loc_sc_varcov} : Provided, if \code{distribution} is not
-#'       \code{"weibull"} or \code{"weibull3"}. Estimated heteroscedasticity-consistent
-#'       variance-covariance matrix for the (log-)location-scale parameters.
-#'     \item \code{r_squared} : Coefficient of determination.
-#'     \item \code{data} : A tibble with class \code{"cdf_estimation"} returned by
-#'       \code{\link{estimate_cdf}}.
-#'     \item \code{distribution} : Specified distribution.
-#'   }
-#'   If more than one method was specified in \code{\link{estimate_cdf}}, the
-#'   resulting output is a list with class \code{"model_estimation_list"}. In
-#'   this case each list element has classes \code{"rank_regression"} and
+#' @template return-rank-regression
+#' @templateVar data A tibble with class \code{"cdf_estimation"} returned from \code{\link{estimate_cdf}}.
+#' @return
+#'   If more than one method was specified in \code{\link{estimate_cdf}},
+#'   the resulting output is a list with class \code{"model_estimation_list"}.
+#'   In this case each list element has classes \code{"rank_regression"} and
 #'   \code{"model_estimation"} and the items listed above, are included.
 #'
 #' @encoding UTF-8
@@ -190,30 +168,8 @@ rank_regression.cdf_estimation <- function(x,
 #' @param status A vector of binary data (0 or 1) indicating whether a unit is
 #'   a right censored observation (= 0) or a failure (= 1).
 #'
-#' @return Returns a list with the classes \code{"rank_regression"} and
-#'   \code{"model_estimation"} containing the following elements:
-#'   \itemize{
-#'     \item \code{coefficients} : If \code{distribution} is \code{"weibull"}, the
-#'       estimated scale (\eqn{\eta}) and shape (\eqn{\beta}) parameters are provided
-#'       (and additionally the threshold parameter \eqn{\gamma} if \code{distribution}
-#'       is \code{"weibull3"}). For any other distribution, \code{coefficients} is
-#'       identical to \code{loc_sc_params}.
-#'     \item \code{confint} : Only included if \code{distribution} is \code{"weibull"}
-#'       or \code{"weibull3"}. Approximated confidence intervals for \eqn{\eta} and
-#'       \eqn{\beta} (and \eqn{\gamma} if \code{distribution} is \code{"weibull3"}).
-#'     \item \code{loc_sc_params} : Estimated (log-)location-scale parameters.
-#'       Threshold parameter is included if \code{distribution} is \code{"weibull3"},
-#'       \code{"lognormal3"} or \code{"loglogistic3"}.
-#'     \item \code{loc_sc_confint} : Confidence intervals for (log-)location-scale
-#'       parameters. If distribution is \code{"lognormal3"} or \code{"loglogistic3"}
-#'       a confidence interval for the threshold parameter is not computed.
-#'     \item \code{loc_sc_varcov} : Provided, if \code{distribution} is not
-#'       \code{"weibull"} or \code{"weibull3"}. Estimated heteroscedasticity-consistent
-#'       variance-covariance matrix for the (log-)location-scale parameters.
-#'     \item \code{r_squared} : Coefficient of determination.
-#'     \item \code{data} : A tibble with columns \code{x}, \code{status} and \code{prob}.
-#'     \item \code{distribution} : Specified distribution.
-#'   }
+#' @template return-rank-regression
+#' @templateVar data A tibble with columns \code{x}, \code{status} and \code{prob}.
 #'
 #' @seealso \code{\link{rank_regression}}
 #'
@@ -332,9 +288,9 @@ rank_regression_ <- function(cdf_estimation,
     r_sq <- summary(mrr)$r.squared
 
     mrr_output <- list(
-      coefficients = estimates,
+      coefficients = estimates_loc_sc,
+      shape_scale_coefficients = estimates,
       confint = conf_ints,
-      loc_sc_params = estimates_loc_sc,
       loc_sc_confint = conf_ints_loc_sc,
       r_squared = r_sq
     )
@@ -413,9 +369,9 @@ rank_regression_ <- function(cdf_estimation,
       r_sq <- summary(mrr)$r.squared
 
       mrr_output <- list(
-        coefficients = estimates,
+        coefficients = estimates_loc_sc,
+        shape_scale_coefficients = estimates,
         confint = conf_ints,
-        loc_sc_params = estimates_loc_sc,
         loc_sc_confint = conf_ints_loc_sc,
         r_squared = r_sq
       )
@@ -463,7 +419,6 @@ rank_regression_ <- function(cdf_estimation,
 
       mrr_output <- list(
         coefficients = estimates_loc_sc,
-        loc_sc_params = estimates_loc_sc,
         loc_sc_confint = conf_ints_loc_sc,
         loc_sc_varcov = vcov_loc_sc,
         r_squared = r_sq
@@ -521,7 +476,6 @@ rank_regression_ <- function(cdf_estimation,
 
     mrr_output <- list(
       coefficients = estimates_loc_sc,
-      loc_sc_params = estimates_loc_sc,
       loc_sc_confint = conf_ints_loc_sc,
       loc_sc_varcov = vcov_loc_sc,
       r_squared = r_sq

--- a/man-roxygen/return-coefficient.R
+++ b/man-roxygen/return-coefficient.R
@@ -1,0 +1,7 @@
+#' \item \code{coefficients} : A named vector of estimated coefficients
+#' (parameters of the assumed distribution). \strong{Note}: The parameters
+#' are given in location-scale-parameterization. If \code{distribution} is
+#' \code{"weibull"} this is not the parameterization used in
+#' \code{\link[stats:Weibull]{stats::Weibull}}. The parameters of the
+#' shape-scale-parameterization are given under
+#' \code{shape_scale_coefficients}.

--- a/man-roxygen/return-ml-estimation.R
+++ b/man-roxygen/return-ml-estimation.R
@@ -1,0 +1,27 @@
+#' @return
+#' Returns a list with the classes \code{"ml_estimation"} and
+#' \code{"model_estimation"} containing the following elements:
+#' \itemize{
+#'   \item \code{coefficients} : A named vector of estimated coefficients
+#'     (parameters of the assumed distribution). \strong{Note}: The parameters
+#'     are given in location-scale-parameterization. If \code{distribution} is
+#'     \code{"weibull"} this is not the parameterization used in
+#'     \code{\link[stats:Weibull]{stats::Weibull}}. The parameters of the
+#'     shape-scale-parameterization are given under
+#'     \code{shape_scale_coefficients}.
+#'   \item \code{shape_scale_coefficients} : Only included if
+#'     \code{distribution} is \code{"weibull"} or \code{"weibull3"}. See
+#'     \code{coefficients}.
+#'   \item \code{confint} : Only included if \code{distribution} is \code{"weibull"}
+#'     or \code{"weibull3"}. Confidence intervals for \eqn{\eta} and \eqn{\beta}
+#'     (and \eqn{\gamma} if \code{distribution} is \code{"weibull3"}).
+#'   \item \code{loc_sc_confint} : Confidence intervals the (log-)location-scale
+#'     parameters.
+#'   \item \code{loc_sc_varcov} : Estimated variance-covariance matrix for the
+#'     (log-)location-scale parameters.
+#'   \item \code{logL} : The log-likelihood value.
+#'   \item \code{aic} : Akaike Information Criterion.
+#'   \item \code{bic} : Bayesian Information Criterion.
+#'   \item \code{data} : <%=data%>
+#'   \item \code{distribution} : Specified distribution.
+#' }

--- a/man-roxygen/return-rank-regression.R
+++ b/man-roxygen/return-rank-regression.R
@@ -1,0 +1,27 @@
+#' @return
+#' Returns a list with the classes \code{"rank_regression"} and
+#' \code{"model_estimation"} containing the following elements:
+#' \itemize{
+#'   \item \code{coefficients} : A named vector of estimated coefficients
+#'     (parameters of the assumed distribution). \strong{Note}: The parameters
+#'     are given in location-scale-parameterization. If \code{distribution} is
+#'     \code{"weibull"} this is not the parameterization used in
+#'     \code{\link[stats:Weibull]{stats::Weibull}}. The parameters of the
+#'     shape-scale-parameterization are given under
+#'     \code{shape_scale_coefficients}.
+#'   \item \code{shape_scale_coefficients} : Only included if
+#'     \code{distribution} is \code{"weibull"} or \code{"weibull3"}. See
+#'     \code{coefficients}.
+#'   \item \code{confint} : Only included if \code{distribution} is \code{"weibull"}
+#'     or \code{"weibull3"}. Approximated confidence intervals for \eqn{\eta} and
+#'     \eqn{\beta} (and \eqn{\gamma} if \code{distribution} is \code{"weibull3"}).
+#'   \item \code{loc_sc_confint} : Confidence intervals for (log-)location-scale
+#'     parameters. If distribution is \code{"lognormal3"} or \code{"loglogistic3"}
+#'     a confidence interval for the threshold parameter is not computed.
+#'   \item \code{loc_sc_varcov} : Provided, if \code{distribution} is not
+#'     \code{"weibull"} or \code{"weibull3"}. Estimated heteroscedasticity-consistent
+#'     variance-covariance matrix for the (log-)location-scale parameters.
+#'   \item \code{r_squared} : Coefficient of determination.
+#'   \item \code{data} : <%=data%>
+#'   \item \code{distribution} : Specified distribution.
+#' }

--- a/man/confint_betabinom.default.Rd
+++ b/man/confint_betabinom.default.Rd
@@ -7,7 +7,7 @@
 \method{confint_betabinom}{default}(
   x,
   status,
-  loc_sc_params,
+  dist_params,
   distribution = c("weibull", "lognormal", "loglogistic", "normal", "logistic", "sev",
     "weibull3", "lognormal3", "loglogistic3"),
   b_lives = c(0.01, 0.1, 0.5),
@@ -26,7 +26,7 @@ cycles.}
 \item{status}{A vector of binary data (0 or 1) indicating whether unit \emph{i}
 is a right censored observation (= 0) or a failure (= 1).}
 
-\item{loc_sc_params}{A (named) numeric vector of (log-)location-scale parameters
+\item{dist_params}{A (named) numeric vector of (log-)location-scale parameters
 returned from \code{\link{rank_regression}}.}
 
 \item{distribution}{Supposed distribution of the random variable. Has to be in
@@ -67,8 +67,9 @@ A tibble with class \code{"confint"} containing the following columns:
     \item \code{distribution} : Specified distribution.
     \item \code{bounds} : Specified bound(s).
     \item \code{direction} : Specified direction.
-    \item \code{method} : A character that is always \code{"conf_null"}. Due to
-      generic visualization functions column \code{method} has to be provided.
+    \item \code{method} : A character that is always \code{NA_character}. Due
+      to the generic visualization functions column \code{method} has to be
+      provided.
   }
 }
 \description{
@@ -122,7 +123,7 @@ rr_2 <- rank_regression(
 conf_betabin_1 <- confint_betabinom(
   x = obs,
   status = status_1,
-  loc_sc_params = rr$loc_sc_params,
+  dist_params = rr$coefficients,
   distribution = "weibull",
   bounds = "two_sided",
   conf_level = 0.95,
@@ -133,7 +134,7 @@ conf_betabin_1 <- confint_betabinom(
 conf_betabin_2_1 <- confint_betabinom(
   x = obs,
   status = status_1,
-  loc_sc_params = rr$loc_sc_params,
+  dist_params = rr$coefficients,
   distribution = "weibull",
   bounds = "lower",
   conf_level = 0.90,
@@ -143,7 +144,7 @@ conf_betabin_2_1 <- confint_betabinom(
 conf_betabin_2_2 <- confint_betabinom(
   x = obs,
   status = status_1,
-  loc_sc_params = rr$loc_sc_params,
+  dist_params = rr$coefficients,
   distribution = "weibull",
   bounds = "upper",
   conf_level = 0.90,
@@ -156,7 +157,7 @@ conf_betabin_2_2 <- confint_betabinom(
 conf_betabin_3_1 <- confint_betabinom(
   x = cycles,
   status = status_2,
-  loc_sc_params = rr_2$loc_sc_params,
+  dist_params = rr_2$coefficients,
   distribution = "lognormal3",
   bounds = "two_sided",
   conf_level = 0.90,
@@ -166,7 +167,7 @@ conf_betabin_3_1 <- confint_betabinom(
 conf_betabin_3_2 <- confint_betabinom(
   x = cycles,
   status = status_2,
-  loc_sc_params = rr_2$loc_sc_params,
+  dist_params = rr_2$coefficients,
   distribution = "lognormal3",
   bounds = "two_sided",
   conf_level = 0.90,

--- a/man/confint_fisher.default.Rd
+++ b/man/confint_fisher.default.Rd
@@ -7,7 +7,7 @@
 \method{confint_fisher}{default}(
   x,
   status,
-  loc_sc_params,
+  dist_params,
   loc_sc_varcov,
   distribution = c("weibull", "lognormal", "loglogistic", "normal", "logistic", "sev",
     "weibull3", "lognormal3", "loglogistic3"),
@@ -27,7 +27,7 @@ cycles.}
 \item{status}{A vector of binary data (0 or 1) indicating whether unit \emph{i}
 is a right censored observation (= 0) or a failure (= 1).}
 
-\item{loc_sc_params}{A (named) numeric vector of (log-)location-scale parameters
+\item{dist_params}{A (named) numeric vector of (log-)location-scale parameters
 returned from \code{\link{ml_estimation}}.}
 
 \item{loc_sc_varcov}{A (named) numeric matrix of estimated variances and
@@ -116,7 +116,7 @@ ml_2 <- ml_estimation(
 conf_fisher_1 <- confint_fisher(
   x = obs,
   status = status_1,
-  loc_sc_params = ml$loc_sc_params,
+  dist_params = ml$coefficients,
   loc_sc_varcov = ml$loc_sc_varcov,
   distribution = "weibull",
   bounds = "two_sided",
@@ -128,7 +128,7 @@ conf_fisher_1 <- confint_fisher(
 conf_fisher_2_1 <- confint_fisher(
   x = obs,
   status = status_1,
-  loc_sc_params = ml$loc_sc_params,
+  dist_params = ml$coefficients,
   loc_sc_varcov = ml$loc_sc_varcov,
   distribution = "weibull",
   bounds = "lower",
@@ -139,7 +139,7 @@ conf_fisher_2_1 <- confint_fisher(
 conf_fisher_2_2 <- confint_fisher(
   x = obs,
   status = status_1,
-  loc_sc_params = ml$loc_sc_params,
+  dist_params = ml$coefficients,
   loc_sc_varcov = ml$loc_sc_varcov,
   distribution = "weibull",
   bounds = "upper",
@@ -153,7 +153,7 @@ conf_fisher_2_2 <- confint_fisher(
 conf_fisher_3_1 <- confint_fisher(
   x = cycles,
   status = status_2,
-  loc_sc_params = ml_2$loc_sc_params,
+  dist_params = ml_2$coefficients,
   loc_sc_varcov = ml_2$loc_sc_varcov,
   distribution = "lognormal3",
   bounds = "two_sided",
@@ -164,7 +164,7 @@ conf_fisher_3_1 <- confint_fisher(
 conf_fisher_3_2 <- confint_fisher(
   x = cycles,
   status = status_2,
-  loc_sc_params = ml_2$loc_sc_params,
+  dist_params = ml_2$coefficients,
   loc_sc_varcov = ml_2$loc_sc_varcov,
   distribution = "lognormal3",
   bounds = "two_sided",

--- a/man/delta_method.Rd
+++ b/man/delta_method.Rd
@@ -7,7 +7,7 @@
 \usage{
 delta_method(
   p,
-  loc_sc_params,
+  dist_params,
   loc_sc_varcov,
   distribution = c("weibull", "lognormal", "loglogistic", "normal", "logistic", "sev",
     "weibull3", "lognormal3", "loglogistic3"),
@@ -20,7 +20,7 @@ of quantiles should be determined the corresponding probabilities have to be
 specified, and if the standard errors of standardized quantiles (z-values)
 should be computed corresponding quantiles are required.}
 
-\item{loc_sc_params}{A (named) numeric vector of (log-)location-scale parameters
+\item{dist_params}{A (named) numeric vector of (log-)location-scale parameters
 returned from \code{\link{ml_estimation}}.}
 
 \item{loc_sc_varcov}{A (named) numeric matrix of estimated variances and
@@ -72,7 +72,7 @@ mle <- ml_estimation(
 # Example 1 - Standard errors of standardized quantiles:
 delta_y <- delta_method(
   p = shock$distance,
-  loc_sc_params = mle$loc_sc_params,
+  dist_params = mle$coefficients,
   loc_sc_varcov = mle$loc_sc_varcov,
   distribution = "weibull",
   direction = "y"
@@ -81,7 +81,7 @@ delta_y <- delta_method(
 # Example 2 - Standard errors of quantiles:
 delta_x <- delta_method(
   p = seq(0.01, 0.99, 0.01),
-  loc_sc_params = mle$loc_sc_params,
+  dist_params = mle$coefficients,
   loc_sc_varcov = mle$loc_sc_varcov,
   distribution = "weibull",
   direction = "x"

--- a/man/estimate_cdf.default.Rd
+++ b/man/estimate_cdf.default.Rd
@@ -8,7 +8,7 @@
   x,
   status,
   id = NULL,
-  methods = c("mr", "johnson", "kaplan", "nelson"),
+  method = c("mr", "johnson", "kaplan", "nelson"),
   options = list(),
   ...
 )
@@ -24,9 +24,8 @@ is a right censored observation (= 0) or a failure (= 1).}
 
 \item{id}{A vector for the identification of every unit. Default is \code{NULL}.}
 
-\item{methods}{One or multiple methods of \code{"mr"}, \code{"johnson"},
-\code{"kaplan"} or \code{"nelson"} used for the estimation of failure
-probabilities. See 'Details'.}
+\item{method}{Method used for the estimation of failure probabilities. See
+'Details'.}
 
 \item{options}{A list of named options. See 'Options'.}
 
@@ -111,31 +110,15 @@ prob_tbl <- estimate_cdf(
   methods = "johnson"
 )
 
-# Example 2 - Multiple methods:
-prob_tbl_2 <- estimate_cdf(
-  x = cycles,
-  status = status,
-  methods = c("johnson", "kaplan", "nelson")
-)
 
-# Example 3 - Method 'mr' with options:
-prob_tbl_3 <- estimate_cdf(
+# Example 2 - Method 'mr' with options:
+prob_tbl_2 <- estimate_cdf(
   x = cycles,
   status = status,
   methods = "mr",
   options = list(
     mr_method = "invbeta",
     mr_ties.method = "average"
-  )
-)
-
-# Example 4 - Multiple methods and option for 'mr':
-prob_tbl_4 <- estimate_cdf(
-  x = cycles,
-  status = status,
-  methods = c("mr", "johnson"),
-  options = list(
-    mr_ties.method = "max"
   )
 )
 

--- a/man/loglik_function.Rd
+++ b/man/loglik_function.Rd
@@ -9,7 +9,7 @@ loglik_function(
   x,
   status,
   wts = rep(1, length(x)),
-  loc_sc_params,
+  dist_params,
   distribution = c("weibull", "lognormal", "loglogistic", "normal", "logistic", "sev",
     "weibull3", "lognormal3", "loglogistic3")
 )
@@ -26,7 +26,7 @@ is a right censored observation (= 0) or a failure (= 1).}
 \item{wts}{Optional vector of case weights. The length of \code{wts} must be the
 same as the number of observations in \code{x}.}
 
-\item{loc_sc_params}{A (named) numeric vector of (log-)location-scale parameters
+\item{dist_params}{A (named) numeric vector of (log-)location-scale parameters
 in the order of location (\eqn{\mu}) and scale (\eqn{\sigma}). If a
 three-parametric model is selected, the threshold parameter (\eqn{\gamma})
 has to be the third element.}
@@ -35,7 +35,7 @@ has to be the third element.}
 }
 \value{
 Returns the log-likelihood value for the data with respect to the parameters
-given in \code{loc_sc_params}.
+given in \code{dist_params}.
 }
 \description{
 This function computes the log-likelihood value with respect to a given set
@@ -54,7 +54,7 @@ status <- alloy$status
 loglik_weib <- loglik_function(
   x = cycles,
   status = status,
-  loc_sc_params = c(5.29, 0.33),
+  dist_params = c(5.29, 0.33),
   distribution = "weibull"
 )
 
@@ -62,7 +62,7 @@ loglik_weib <- loglik_function(
 loglik_weib3 <- loglik_function(
   x = cycles,
   status = status,
-  loc_sc_params = c(4.54, 0.76, 92.99),
+  dist_params = c(4.54, 0.76, 92.99),
   distribution = "weibull3"
 )
 

--- a/man/ml_estimation.Rd
+++ b/man/ml_estimation.Rd
@@ -32,30 +32,31 @@ same as the number of observations in \code{x}.}
 }
 \value{
 Returns a list with the classes \code{"ml_estimation"} and
-  \code{"model_estimation"} containing the following elements:
-  \itemize{
-    \item \code{coefficients} : If \code{distribution} is \code{"weibull"}, the
-      estimated scale (\eqn{\eta}) and shape (\eqn{\beta}) parameters are provided
-      (and additionally the threshold parameter \eqn{\gamma} if \code{distribution}
-      is \code{"weibull3"}). For any other distribution, \code{coefficients} is
-      identical to \code{loc_sc_params}.
-    \item \code{confint} : Only included if \code{distribution} is \code{"weibull"}
-      or \code{"weibull3"}. Confidence intervals for \eqn{\eta} and \eqn{\beta}
-      (and \eqn{\gamma} if \code{distribution} is \code{"weibull3"}).
-    \item \code{loc_sc_params} : Estimated (log-)location-scale parameters.
-      Threshold parameter is included if \code{distribution} is \code{"weibull3"},
-      \code{"lognormal3"} or \code{"loglogistic3"}.
-    \item \code{loc_sc_confint} : Confidence intervals the (log-)location-scale
-      parameters.
-    \item \code{loc_sc_varcov} : Estimated variance-covariance matrix for the
-      (log-)location-scale parameters.
-    \item \code{logL} : The log-likelihood value.
-    \item \code{aic} : Akaike Information Criterion.
-    \item \code{bic} : Bayesian Information Criterion.
-    \item \code{data} : A tibble with class \code{"reliability_data"} returned
-      by \code{\link{reliability_data}}.
-    \item \code{distribution} : Specified distribution.
-  }
+\code{"model_estimation"} containing the following elements:
+\itemize{
+  \item \code{coefficients} : A named vector of estimated coefficients
+    (parameters of the assumed distribution). \strong{Note}: The parameters
+    are given in location-scale-parameterization. If \code{distribution} is
+    \code{"weibull"} this is not the parameterization used in
+    \code{\link[stats:Weibull]{stats::Weibull}}. The parameters of the
+    shape-scale-parameterization are given under
+    \code{shape_scale_coefficients}.
+  \item \code{shape_scale_coefficients} : Only included if
+    \code{distribution} is \code{"weibull"} or \code{"weibull3"}. See
+    \code{coefficients}.
+  \item \code{confint} : Only included if \code{distribution} is \code{"weibull"}
+    or \code{"weibull3"}. Confidence intervals for \eqn{\eta} and \eqn{\beta}
+    (and \eqn{\gamma} if \code{distribution} is \code{"weibull3"}).
+  \item \code{loc_sc_confint} : Confidence intervals the (log-)location-scale
+    parameters.
+  \item \code{loc_sc_varcov} : Estimated variance-covariance matrix for the
+    (log-)location-scale parameters.
+  \item \code{logL} : The log-likelihood value.
+  \item \code{aic} : Akaike Information Criterion.
+  \item \code{bic} : Bayesian Information Criterion.
+  \item \code{data} : A tibble with class \code{"reliability_data"} returned from \code{\link{reliability_data}}.
+  \item \code{distribution} : Specified distribution.
+}
 }
 \description{
 This function estimates the parameters of a two- or three-parametric lifetime

--- a/man/ml_estimation.default.Rd
+++ b/man/ml_estimation.default.Rd
@@ -34,29 +34,31 @@ same as the number of observations in \code{x}.}
 }
 \value{
 Returns a list with the classes \code{"ml_estimation"} and
-  \code{"model_estimation"} containing the following elements:
-  \itemize{
-    \item \code{coefficients} : If \code{distribution} is \code{"weibull"}, the
-      estimated scale (\eqn{\eta}) and shape (\eqn{\beta}) parameters are provided
-      (and additionally the threshold parameter \eqn{\gamma} if \code{distribution}
-      is \code{"weibull3"}). For any other distribution, \code{coefficients} is
-      identical to \code{loc_sc_params}.
-    \item \code{confint} : Only included if \code{distribution} is \code{"weibull"}
-      or \code{"weibull3"}. Confidence intervals for \eqn{\eta} and \eqn{\beta}
-      (and \eqn{\gamma} if \code{distribution} is \code{"weibull3"}).
-    \item \code{loc_sc_params} : Estimated (log-)location-scale parameters.
-      Threshold parameter is included if \code{distribution} is \code{"weibull3"},
-      \code{"lognormal3"} or \code{"loglogistic3"}.
-    \item \code{loc_sc_confint} : Confidence intervals the (log-)location-scale
-      parameters.
-    \item \code{loc_sc_varcov} : Estimated variance-covariance matrix for the
-      (log-)location-scale parameters.
-    \item \code{logL} : The log-likelihood value.
-    \item \code{aic} : Akaike Information Criterion.
-    \item \code{bic} : Bayesian Information Criterion.
-    \item \code{data} : A tibble with columns \code{x} and \code{status}.
-    \item \code{distribution} : Specified distribution.
-  }
+\code{"model_estimation"} containing the following elements:
+\itemize{
+  \item \code{coefficients} : A named vector of estimated coefficients
+    (parameters of the assumed distribution). \strong{Note}: The parameters
+    are given in location-scale-parameterization. If \code{distribution} is
+    \code{"weibull"} this is not the parameterization used in
+    \code{\link[stats:Weibull]{stats::Weibull}}. The parameters of the
+    shape-scale-parameterization are given under
+    \code{shape_scale_coefficients}.
+  \item \code{shape_scale_coefficients} : Only included if
+    \code{distribution} is \code{"weibull"} or \code{"weibull3"}. See
+    \code{coefficients}.
+  \item \code{confint} : Only included if \code{distribution} is \code{"weibull"}
+    or \code{"weibull3"}. Confidence intervals for \eqn{\eta} and \eqn{\beta}
+    (and \eqn{\gamma} if \code{distribution} is \code{"weibull3"}).
+  \item \code{loc_sc_confint} : Confidence intervals the (log-)location-scale
+    parameters.
+  \item \code{loc_sc_varcov} : Estimated variance-covariance matrix for the
+    (log-)location-scale parameters.
+  \item \code{logL} : The log-likelihood value.
+  \item \code{aic} : Akaike Information Criterion.
+  \item \code{bic} : Bayesian Information Criterion.
+  \item \code{data} : A tibble with class \code{"reliability_data"} returned from \code{\link{reliability_data}}.
+  \item \code{distribution} : Specified distribution.
+}
 }
 \description{
 This function estimates the parameters of a two- or three-parametric lifetime

--- a/man/plot_conf.Rd
+++ b/man/plot_conf.Rd
@@ -50,96 +50,71 @@ probability plot which also includes the estimated regression line.
 }
 
 \examples{
-# Alloy T7987 dataset taken from Meeker and Escobar(1998, p. 131)
-cycles   <- c(300, 300, 300, 300, 300, 291, 274, 271, 269, 257, 256, 227, 226,
-              224, 213, 211, 205, 203, 197, 196, 190, 189, 188, 187, 184, 180,
-              180, 177, 176, 173, 172, 171, 170, 170, 169, 168, 168, 162, 159,
-              159, 159, 159, 152, 152, 149, 149, 144, 143, 141, 141, 140, 139,
-              139, 136, 135, 133, 131, 129, 123, 121, 121, 118, 117, 117, 114,
-              112, 108, 104, 99, 99, 96, 94)
-state <- c(rep(0, 5), rep(1, 67))
-id <- 1:length(cycles)
+data <- reliability_data(data = alloy, x = cycles, status = status)
 
-df_john <- johnson_method(x = cycles, status = state, id = id)
-# Example 1: Probability Plot, Regression Line and Confidence Bounds for Three-Parameter-Weibull:
-mrr <- rank_regression(x = df_john$x,
-                       y = df_john$prob,
-                       status = df_john$status,
-                       distribution = "weibull3",
-                       conf_level = .90)
+prob_tbl <- estimate_cdf(data, methods = "johnson")
 
-conf_betabin <- confint_betabinom(x = df_john$x,
-                                  status = df_john$status,
-                                  loc_sc_params = mrr$loc_sc_params,
-                                  distribution = "weibull3",
-                                  bounds = "two_sided",
-                                  conf_level = 0.95,
-                                  direction = "y")
+# Example 1 - Probability Plot, Regression Line and Confidence Bounds for Three-Parameter-Weibull:
+rr <- rank_regression(
+  x = prob_tbl,
+  distribution = "weibull3",
+  conf_level = 0.9
+)
 
-plot_weibull <- plot_prob(x = df_john$x,
-                          y = df_john$prob,
-                          status = df_john$status,
-                          id = df_john$id,
-                          distribution = "weibull",
-                          title_main = "Three-Parametric Weibull",
-                          title_x = "Cycles",
-                          title_y = "Probability of Failure in \%",
-                          title_trace = "Failed Items")
+conf_betabin <- confint_betabinom(
+  x = rr,
+  bounds = "two_sided",
+  conf_level = 0.95,
+  direction = "y"
+)
 
-plot_reg_weibull <- plot_mod(p_obj = plot_weibull,
-                             x = conf_betabin$x,
-                             y = conf_betabin$prob,
-                             loc_sc_params = mrr$loc_sc_params,
-                             distribution = "weibull3",
-                             title_trace = "Estimated Weibull CDF")
+plot_weibull <- plot_prob(
+  x = prob_tbl,
+  distribution = "weibull",
+  title_main = "Three-Parametric Weibull",
+  title_x = "Cycles",
+  title_y = "Probability of Failure in \%",
+  title_trace = "Failed Items"
+)
 
-plot_conf_beta <- plot_conf(p_obj = plot_reg_weibull,
-                            x = list(conf_betabin$x),
-                            y = list(conf_betabin$lower_bound,
-                                     conf_betabin$upper_bound),
-                            direction = "y",
-                            distribution = "weibull3",
-                            title_trace = "Confidence Region")
+plot_conf_beta <- plot_conf(
+  p_obj = plot_weibull,
+  x = conf_betabin,
+  mod = rr,
+  title_trace_mod = "Estimated Weibull CDF",
+  title_trace_conf = "Confidence Region"
+)
 
-# Example 2: Probability Plot, Regression Line and Confidence Bounds for Three-Parameter-Lognormal:
-mrr_ln <- rank_regression(x = df_john$x,
-                       y = df_john$prob,
-                       status = df_john$status,
-                       distribution = "lognormal3",
-                       conf_level = .90)
+# Example 2 - Probability Plot, Regression Line and Confidence Bounds for Three-Parameter-Lognormal:
+rr_ln <- rank_regression(
+  x = prob_tbl,
+  distribution = "lognormal3",
+  conf_level = 0.9
+)
 
-conf_betabin_ln <- confint_betabinom(x = df_john$x,
-                                  status = df_john$status,
-                                  loc_sc_params = mrr_ln$loc_sc_params,
-                                  distribution = "lognormal3",
-                                  bounds = "two_sided",
-                                  conf_level = 0.95,
-                                  direction = "y")
+conf_betabin_ln <- confint_betabinom(
+  x = rr_ln,
+  bounds = "two_sided",
+  conf_level = 0.9,
+  direction = "y"
+)
 
-plot_lognormal <- plot_prob(x = df_john$x,
-                          y = df_john$prob,
-                          status = df_john$status,
-                          id = df_john$id,
-                          distribution = "lognormal",
-                          title_main = "Three-Parametric Lognormal",
-                          title_x = "Cycles",
-                          title_y = "Probability of Failure in \%",
-                          title_trace = "Failed Items")
+plot_lognormal <- plot_prob(
+  x = prob_tbl,
+  distribution = "lognormal",
+  title_main = "Three-Parametric Lognormal",
+  title_x = "Cycles",
+  title_y = "Probability of Failure in \%",
+  title_trace = "Failed Items"
+)
 
-plot_reg_lognormal <- plot_mod(p_obj = plot_lognormal,
-                             x = conf_betabin_ln$x,
-                             y = conf_betabin_ln$prob,
-                             loc_sc_params = mrr_ln$loc_sc_params,
-                             distribution = "lognormal3",
-                             title_trace = "Estimated Lognormal CDF")
-
-plot_conf_beta_ln <- plot_conf(p_obj = plot_reg_lognormal,
-                            x = list(conf_betabin_ln$x),
-                            y = list(conf_betabin_ln$lower_bound,
-                                     conf_betabin_ln$upper_bound),
-                            direction = "y",
-                            distribution = "lognormal3",
-                            title_trace = "Confidence Region")
+plot_conf_beta_ln <- plot_conf(
+  p_obj = plot_lognormal,
+  x = conf_betabin_ln,
+  mod = rr_ln,
+  title_trace_fit = "Estimated Lognormal CDF",
+  title_trace_conf = "Confidence Region"
+)
 
 }
 \references{

--- a/man/plot_conf.default.Rd
+++ b/man/plot_conf.default.Rd
@@ -82,7 +82,7 @@ rr <- rank_regression(
 conf_betabin <- confint_betabinom(
   x = tbl_john$x,
   status = tbl_john$status,
-  loc_sc_params = rr$loc_sc_params,
+  dist_params = rr$coefficients,
   distribution = "weibull3",
   bounds = "two_sided",
   conf_level = 0.95,
@@ -105,7 +105,7 @@ plot_reg_weibull <- plot_mod(
   p_obj = plot_weibull,
   x = conf_betabin$x,
   y = conf_betabin$prob,
-  loc_sc_params = rr$loc_sc_params,
+  dist_params = rr$coefficients,
   distribution = "weibull3",
   title_trace = "Estimated Weibull CDF"
 )
@@ -131,7 +131,7 @@ rr_ln <- rank_regression(
 conf_betabin_ln <- confint_betabinom(
   x = tbl_john$x,
   status = tbl_john$status,
-  loc_sc_params = rr_ln$loc_sc_params,
+  dist_params = rr_ln$coefficients,
   distribution = "lognormal3",
   bounds = "two_sided",
   conf_level = 0.95,
@@ -154,7 +154,7 @@ plot_reg_lognormal <- plot_mod(
   p_obj = plot_lognormal,
   x = conf_betabin_ln$x,
   y = conf_betabin_ln$prob,
-  loc_sc_params = rr_ln$loc_sc_params,
+  dist_params = rr_ln$coefficients,
   distribution = "lognormal3",
   title_trace = "Estimated Lognormal CDF"
 )

--- a/man/plot_conf.default.Rd
+++ b/man/plot_conf.default.Rd
@@ -40,6 +40,8 @@ Returns a plot object containing the probability plot with
   confidence region(s).
 }
 \description{
+\lifecycle{soft-deprecated}
+
 This function is used to add estimated confidence region(s) to an existing
 probability plot which also includes the estimated regression line.
 }
@@ -64,89 +66,107 @@ cycles   <- c(300, 300, 300, 300, 300, 291, 274, 271, 269, 257, 256, 227, 226,
               159, 159, 159, 152, 152, 149, 149, 144, 143, 141, 141, 140, 139,
               139, 136, 135, 133, 131, 129, 123, 121, 121, 118, 117, 117, 114,
               112, 108, 104, 99, 99, 96, 94)
-state <- c(rep(0, 5), rep(1, 67))
-id <- 1:length(cycles)
+status <- c(rep(0, 5), rep(1, 67))
 
-df_john <- johnson_method(x = cycles, status = state, id = id)
+tbl_john <- estimate_cdf(x = cycles, status = status, method = "johnson")
+
 # Example 1: Probability Plot, Regression Line and Confidence Bounds for Three-Parameter-Weibull:
-mrr <- rank_regression(x = df_john$x,
-                       y = df_john$prob,
-                       status = df_john$status,
-                       distribution = "weibull3",
-                       conf_level = .90)
+rr <- rank_regression(
+  x = tbl_john$x,
+  y = tbl_john$prob,
+  status = tbl_john$status,
+  distribution = "weibull3",
+  conf_level = .90
+)
 
-conf_betabin <- confint_betabinom(x = df_john$x,
-                                  status = df_john$status,
-                                  loc_sc_params = mrr$loc_sc_params,
-                                  distribution = "weibull3",
-                                  bounds = "two_sided",
-                                  conf_level = 0.95,
-                                  direction = "y")
+conf_betabin <- confint_betabinom(
+  x = tbl_john$x,
+  status = tbl_john$status,
+  loc_sc_params = rr$loc_sc_params,
+  distribution = "weibull3",
+  bounds = "two_sided",
+  conf_level = 0.95,
+  direction = "y"
+)
 
-plot_weibull <- plot_prob(x = df_john$x,
-                          y = df_john$prob,
-                          status = df_john$status,
-                          id = df_john$id,
-                          distribution = "weibull",
-                          title_main = "Three-Parametric Weibull",
-                          title_x = "Cycles",
-                          title_y = "Probability of Failure in \%",
-                          title_trace = "Failed Items")
+plot_weibull <- plot_prob(
+  x = tbl_john$x,
+  y = tbl_john$prob,
+  status = tbl_john$status,
+  id = tbl_john$id,
+  distribution = "weibull",
+  title_main = "Three-Parametric Weibull",
+  title_x = "Cycles",
+  title_y = "Probability of Failure in \%",
+  title_trace = "Failed Items"
+)
 
-plot_reg_weibull <- plot_mod(p_obj = plot_weibull,
-                             x = conf_betabin$x,
-                             y = conf_betabin$prob,
-                             loc_sc_params = mrr$loc_sc_params,
-                             distribution = "weibull3",
-                             title_trace = "Estimated Weibull CDF")
+plot_reg_weibull <- plot_mod(
+  p_obj = plot_weibull,
+  x = conf_betabin$x,
+  y = conf_betabin$prob,
+  loc_sc_params = rr$loc_sc_params,
+  distribution = "weibull3",
+  title_trace = "Estimated Weibull CDF"
+)
 
-plot_conf_beta <- plot_conf(p_obj = plot_reg_weibull,
-                            x = list(conf_betabin$x),
-                            y = list(conf_betabin$lower_bound,
-                                     conf_betabin$upper_bound),
-                            direction = "y",
-                            distribution = "weibull3",
-                            title_trace = "Confidence Region")
+plot_conf_beta <- plot_conf(
+  p_obj = plot_reg_weibull,
+  x = list(conf_betabin$x),
+  y = list(conf_betabin$lower_bound, conf_betabin$upper_bound),
+  direction = "y",
+  distribution = "weibull3",
+  title_trace = "Confidence Region"
+)
 
 # Example 2: Probability Plot, Regression Line and Confidence Bounds for Three-Parameter-Lognormal:
-mrr_ln <- rank_regression(x = df_john$x,
-                       y = df_john$prob,
-                       status = df_john$status,
-                       distribution = "lognormal3",
-                       conf_level = .90)
+rr_ln <- rank_regression(
+  x = tbl_john$x,
+  y = tbl_john$prob,
+  status = tbl_john$status,
+  distribution = "lognormal3",
+  conf_level = 0.9
+)
 
-conf_betabin_ln <- confint_betabinom(x = df_john$x,
-                                  status = df_john$status,
-                                  loc_sc_params = mrr_ln$loc_sc_params,
-                                  distribution = "lognormal3",
-                                  bounds = "two_sided",
-                                  conf_level = 0.95,
-                                  direction = "y")
+conf_betabin_ln <- confint_betabinom(
+  x = tbl_john$x,
+  status = tbl_john$status,
+  loc_sc_params = rr_ln$loc_sc_params,
+  distribution = "lognormal3",
+  bounds = "two_sided",
+  conf_level = 0.95,
+  direction = "y"
+)
 
-plot_lognormal <- plot_prob(x = df_john$x,
-                          y = df_john$prob,
-                          status = df_john$status,
-                          id = df_john$id,
-                          distribution = "lognormal",
-                          title_main = "Three-Parametric Lognormal",
-                          title_x = "Cycles",
-                          title_y = "Probability of Failure in \%",
-                          title_trace = "Failed Items")
+plot_lognormal <- plot_prob(
+  x = tbl_john$x,
+  y = tbl_john$prob,
+  status = tbl_john$status,
+  id = tbl_john$id,
+  distribution = "lognormal",
+  title_main = "Three-Parametric Lognormal",
+  title_x = "Cycles",
+  title_y = "Probability of Failure in \%",
+  title_trace = "Failed Items"
+)
 
-plot_reg_lognormal <- plot_mod(p_obj = plot_lognormal,
-                             x = conf_betabin_ln$x,
-                             y = conf_betabin_ln$prob,
-                             loc_sc_params = mrr_ln$loc_sc_params,
-                             distribution = "lognormal3",
-                             title_trace = "Estimated Lognormal CDF")
+plot_reg_lognormal <- plot_mod(
+  p_obj = plot_lognormal,
+  x = conf_betabin_ln$x,
+  y = conf_betabin_ln$prob,
+  loc_sc_params = rr_ln$loc_sc_params,
+  distribution = "lognormal3",
+  title_trace = "Estimated Lognormal CDF"
+)
 
-plot_conf_beta_ln <- plot_conf(p_obj = plot_reg_lognormal,
-                            x = list(conf_betabin_ln$x),
-                            y = list(conf_betabin_ln$lower_bound,
-                                     conf_betabin_ln$upper_bound),
-                            direction = "y",
-                            distribution = "lognormal3",
-                            title_trace = "Confidence Region")
+plot_conf_beta_ln <- plot_conf(
+  p_obj = plot_reg_lognormal,
+  x = list(conf_betabin_ln$x),
+  y = list(conf_betabin_ln$lower_bound, conf_betabin_ln$upper_bound),
+  direction = "y",
+  distribution = "lognormal3",
+  title_trace = "Confidence Region"
+)
 
 }
 \references{

--- a/man/plot_mod.default.Rd
+++ b/man/plot_mod.default.Rd
@@ -54,13 +54,14 @@ cycles   <- c(300, 300, 300, 300, 300, 291, 274, 271, 269, 257, 256, 227, 226,
               112, 108, 104, 99, 99, 96, 94)
 status <- c(rep(0, 5), rep(1, 67))
 
-data <- reliability_data(x = cycles, status = status)
-
-tbl_john <- estimate_cdf(data, methods = c("johnson", "nelson"))
+tbl_john <- estimate_cdf(x = cycles, status = status, method = "johnson")
 
 # Example 1: Probability Plot and Regression Line Three-Parameter-Weibull:
 plot_weibull <- plot_prob(
-  tbl_john,
+  x = tbl_john$x,
+  y = tbl_john$prob,
+  status = tbl_john$status,
+  id = tbl_john$id,
   distribution = "weibull",
   title_main = "Three-Parametric Weibull",
   title_x = "Cycles",
@@ -68,15 +69,19 @@ plot_weibull <- plot_prob(
   title_trace = "Failed Items"
 )
 
-mrr <- rank_regression(
-  tbl_john,
+rr <- rank_regression(
+  x = tbl_john$x,
+  y = tbl_john$prob,
+  status = tbl_john$status,
   distribution = "weibull3",
-  conf_level = .90
+  conf_level = 0.9
 )
 
 plot_reg_weibull <- plot_mod(
   p_obj = plot_weibull,
-  x = mrr,
+  x = tbl_john$x,
+  loc_sc_params = rr$loc_sc_params,
+  distribution = "weibull3",
   title_trace = "Estimated Weibull CDF"
 )
 
@@ -84,7 +89,10 @@ plot_reg_weibull <- plot_mod(
 
 # Example 2: Probability Plot and Regression Line Three-Parameter-Lognormal:
 plot_lognormal <- plot_prob(
-  tbl_john,
+  x = tbl_john$x,
+  y = tbl_john$prob,
+  status = tbl_john$status,
+  id = tbl_john$id,
   distribution = "lognormal",
   title_main = "Three-Parametric Lognormal",
   title_x = "Cycles",
@@ -92,15 +100,19 @@ plot_lognormal <- plot_prob(
   title_trace = "Failed Items"
 )
 
-mrr_ln <- rank_regression(
-  tbl_john,
+rr_ln <- rank_regression(
+  x = tbl_john$x,
+  y = tbl_john$prob,
+  status = tbl_john$status,
   distribution = "lognormal3",
-  conf_level = .90
+  conf_level = 0.9
 )
 
 plot_reg_lognormal <- plot_mod(
   p_obj = plot_lognormal,
-  x = mrr_ln,
+  x = tbl_john$x,
+  loc_sc_params = rr_ln$loc_sc_params,
+  distribution = "lognormal3",
   title_trace = "Estimated Lognormal CDF"
 )
 

--- a/man/plot_mod.default.Rd
+++ b/man/plot_mod.default.Rd
@@ -7,7 +7,7 @@
 \method{plot_mod}{default}(
   p_obj,
   x,
-  loc_sc_params,
+  dist_params,
   distribution = c("weibull", "lognormal", "loglogistic", "normal", "logistic", "sev",
     "weibull3", "lognormal3", "loglogistic3"),
   title_trace = "Fit",
@@ -19,7 +19,7 @@
 
 \item{x}{A numeric vector containing the x-coordinates of the regression line.}
 
-\item{loc_sc_params}{A (named) numeric vector of estimated location
+\item{dist_params}{A (named) numeric vector of estimated location
 and scale parameters for a specified distribution. The order of
 elements is important. First entry needs to be the location
 parameter \eqn{\mu} and the second element needs to be the scale
@@ -80,7 +80,7 @@ rr <- rank_regression(
 plot_reg_weibull <- plot_mod(
   p_obj = plot_weibull,
   x = tbl_john$x,
-  loc_sc_params = rr$loc_sc_params,
+  dist_params = rr$coefficients,
   distribution = "weibull3",
   title_trace = "Estimated Weibull CDF"
 )
@@ -111,7 +111,7 @@ rr_ln <- rank_regression(
 plot_reg_lognormal <- plot_mod(
   p_obj = plot_lognormal,
   x = tbl_john$x,
-  loc_sc_params = rr_ln$loc_sc_params,
+  dist_params = rr_ln$coefficients,
   distribution = "lognormal3",
   title_trace = "Estimated Lognormal CDF"
 )

--- a/man/plot_mod_mix.Rd
+++ b/man/plot_mod_mix.Rd
@@ -40,6 +40,8 @@ Returns a plot object containing the probability plot with
   plotting positions and estimated regression line(s).
 }
 \description{
+\lifecycle{soft-deprecated}
+
 This function adds one or multiple estimated regression lines to an existing
 probability plot (\code{\link{plot_prob}}). Depending on the output of the
 function \code{\link{mixmod_regression}} or \code{\link{mixmod_em}} one or

--- a/man/plot_pop.Rd
+++ b/man/plot_pop.Rd
@@ -7,7 +7,7 @@
 plot_pop(
   p_obj = NULL,
   x,
-  loc_sc_params_tbl,
+  dist_params_tbl,
   distribution = c("weibull", "lognormal", "loglogistic", "normal", "logistic", "sev"),
   tol = 1e-06,
   title_trace = "Population",
@@ -24,13 +24,13 @@ between \code{x[1]} and \code{x[2]} is created. This sequence is equidistant
 with respect to the scale of the x axis. If \code{length(x) > 2} the elements
 of \code{x} are the x coordinates of the population line.}
 
-\item{loc_sc_params_tbl}{A tibble. See 'Details'.}
+\item{dist_params_tbl}{A tibble. See 'Details'.}
 
 \item{distribution}{Supposed distribution of the random variable. In the
 context of this function \code{"weibull"}, \code{"lognormal"} and
 \code{"loglogistic"} stand for the two- \strong{and} the three-parametric
 version of the respective distribution. The distinction is made via
-\code{loc_sc_params_tbl}.}
+\code{dist_params_tbl}.}
 
 \item{tol}{The failure probability is restricted to the interval
 \eqn{[tol, 1 - tol]}. The default value is in accordance with the decimal
@@ -50,7 +50,7 @@ A plot object which contains the linearized CDF(s).
 This function adds one or multiple linearized CDFs to an existing plot grid.
 }
 \details{
-\code{loc_sc_params_tbl} is a data.frame with two or three columns. For
+\code{dist_params_tbl} is a data.frame with two or three columns. For
 location-scale distributions the first column contains the location parameter
 and the second column contains the scale parameter. For three-parametric
 distributions the third column contains the threshold parameter.
@@ -72,7 +72,7 @@ grid_weibull <- plot_layout(
 pop_weibull <- plot_pop(
   p_obj = grid_weibull,
   x = range(x),
-  loc_sc_params_tbl = c(log(20000), 1),
+  dist_params_tbl = c(log(20000), 1),
   distribution = "weibull",
   title_trace = "Population"
 )
@@ -83,7 +83,7 @@ x2 <- rweibull(n = 100, shape = 1, scale = 20000) + 5000
 pop_weibull_2 <- plot_pop(
   p_obj = NULL,
   x = x2,
-  loc_sc_params_tbl = c(log(20000 - 5000), 1, 5000),
+  dist_params_tbl = c(log(20000 - 5000), 1, 5000),
   distribution = "weibull",
   title_trace = "Population"
 )
@@ -92,7 +92,7 @@ pop_weibull_2 <- plot_pop(
 pop_weibull_3 <- plot_pop(
   p_obj = NULL,
   x = x,
-  loc_sc_params_tbl = tibble(
+  dist_params_tbl = tibble(
     p_1 = c(log(20000), log(20000), log(20000)),
     p_2 = c(1, 1.5, 2)
     ),
@@ -105,7 +105,7 @@ pop_weibull_3 <- plot_pop(
 pop_weibull_4 <- plot_pop(
   p_obj = NULL,
   x = x,
-  loc_sc_params_tbl = tibble(
+  dist_params_tbl = tibble(
     param_1 = c(log(20000), log(20000)),
     param_2 = c(1, 1),
     param_3 = c(NA, 5)

--- a/man/predict_prob.Rd
+++ b/man/predict_prob.Rd
@@ -6,7 +6,7 @@
 \usage{
 predict_prob(
   q,
-  loc_sc_params,
+  dist_params,
   distribution = c("weibull", "lognormal", "loglogistic", "normal", "logistic", "sev",
     "weibull3", "lognormal3", "loglogistic3")
 )
@@ -14,7 +14,7 @@ predict_prob(
 \arguments{
 \item{q}{A numeric vector of quantiles.}
 
-\item{loc_sc_params}{A (named) numeric vector of (log-)location-scale parameters
+\item{dist_params}{A (named) numeric vector of (log-)location-scale parameters
 in the order of location (\eqn{\mu}) and scale (\eqn{\sigma}). If a
 three-parametric model is selected, the threshold parameter (\eqn{\gamma})
 has to be the third element.}
@@ -36,14 +36,14 @@ of the chosen model are determined.
 # Example 1 - Predicted probabilities for a two-parameter weibull distribution:
 probs_weib2 <- predict_prob(
   q = c(15, 48, 124),
-  loc_sc_params = c(5, 0.5),
+  dist_params = c(5, 0.5),
   distribution = "weibull"
 )
 
 # Example 2 - Predicted quantiles for a three-parameter weibull distribution:
 probs_weib3 <- predict_prob(
   q = c(25, 58, 134),
-  loc_sc_params = c(5, 0.5, 10),
+  dist_params = c(5, 0.5, 10),
   distribution = "weibull3"
 )
 

--- a/man/predict_quantile.Rd
+++ b/man/predict_quantile.Rd
@@ -6,7 +6,7 @@
 \usage{
 predict_quantile(
   p,
-  loc_sc_params,
+  dist_params,
   distribution = c("weibull", "lognormal", "loglogistic", "normal", "logistic", "sev",
     "weibull3", "lognormal3", "loglogistic3")
 )
@@ -14,7 +14,7 @@ predict_quantile(
 \arguments{
 \item{p}{A numeric vector of probabilities.}
 
-\item{loc_sc_params}{A (named) numeric vector of (log-)location-scale parameters
+\item{dist_params}{A (named) numeric vector of (log-)location-scale parameters
 in the order of location (\eqn{\mu}) and scale (\eqn{\sigma}). If a
 three-parametric model is selected, the threshold parameter (\eqn{\gamma})
 has to be the third element.}
@@ -36,14 +36,14 @@ of the chosen model are determined.
 # Example 1 - Predicted quantiles for a two-parameter weibull distribution:
 quants_weib2 <- predict_quantile(
   p = c(0.01, 0.1, 0.5),
-  loc_sc_params = c(5, 0.5),
+  dist_params = c(5, 0.5),
   distribution = "weibull"
 )
 
 # Example 2 - Predicted quantiles for a three-parameter weibull distribution:
 quants_weib3 <- predict_quantile(
   p = c(0.01, 0.1, 0.5),
-  loc_sc_params = c(5, 0.5, 10),
+  dist_params = c(5, 0.5, 10),
   distribution = "weibull3"
 )
 

--- a/man/rank_regression.Rd
+++ b/man/rank_regression.Rd
@@ -29,33 +29,35 @@ rank_regression(x, ...)
 }
 \value{
 Returns a list with the classes \code{"rank_regression"} and
-  \code{"model_estimation"} containing the following elements:
-  \itemize{
-    \item \code{coefficients} : If \code{distribution} is \code{"weibull"}, the
-      estimated scale (\eqn{\eta}) and shape (\eqn{\beta}) parameters are provided
-      (and additionally the threshold parameter \eqn{\gamma} if \code{distribution}
-      is \code{"weibull3"}). For any other distribution, \code{coefficients} is
-      identical to \code{loc_sc_params}.
-    \item \code{confint} : Only included if \code{distribution} is \code{"weibull"}
-      or \code{"weibull3"}. Approximated confidence intervals for \eqn{\eta} and
-      \eqn{\beta} (and \eqn{\gamma} if \code{distribution} is \code{"weibull3"}).
-    \item \code{loc_sc_params} : Estimated (log-)location-scale parameters.
-      Threshold parameter is included if \code{distribution} is \code{"weibull3"},
-      \code{"lognormal3"} or \code{"loglogistic3"}.
-    \item \code{loc_sc_confint} : Confidence intervals for (log-)location-scale
-      parameters. If distribution is \code{"lognormal3"} or \code{"loglogistic3"}
-      a confidence interval for the threshold parameter is not computed.
-    \item \code{loc_sc_varcov} : Provided, if \code{distribution} is not
-      \code{"weibull"} or \code{"weibull3"}. Estimated heteroscedasticity-consistent
-      variance-covariance matrix for the (log-)location-scale parameters.
-    \item \code{r_squared} : Coefficient of determination.
-    \item \code{data} : A tibble with class \code{"cdf_estimation"} returned by
-      \code{\link{estimate_cdf}}.
-    \item \code{distribution} : Specified distribution.
-  }
-  If more than one method was specified in \code{\link{estimate_cdf}}, the
-  resulting output is a list with class \code{"model_estimation_list"}. In
-  this case each list element has classes \code{"rank_regression"} and
+\code{"model_estimation"} containing the following elements:
+\itemize{
+  \item \code{coefficients} : A named vector of estimated coefficients
+    (parameters of the assumed distribution). \strong{Note}: The parameters
+    are given in location-scale-parameterization. If \code{distribution} is
+    \code{"weibull"} this is not the parameterization used in
+    \code{\link[stats:Weibull]{stats::Weibull}}. The parameters of the
+    shape-scale-parameterization are given under
+    \code{shape_scale_coefficients}.
+  \item \code{shape_scale_coefficients} : Only included if
+    \code{distribution} is \code{"weibull"} or \code{"weibull3"}. See
+    \code{coefficients}.
+  \item \code{confint} : Only included if \code{distribution} is \code{"weibull"}
+    or \code{"weibull3"}. Approximated confidence intervals for \eqn{\eta} and
+    \eqn{\beta} (and \eqn{\gamma} if \code{distribution} is \code{"weibull3"}).
+  \item \code{loc_sc_confint} : Confidence intervals for (log-)location-scale
+    parameters. If distribution is \code{"lognormal3"} or \code{"loglogistic3"}
+    a confidence interval for the threshold parameter is not computed.
+  \item \code{loc_sc_varcov} : Provided, if \code{distribution} is not
+    \code{"weibull"} or \code{"weibull3"}. Estimated heteroscedasticity-consistent
+    variance-covariance matrix for the (log-)location-scale parameters.
+  \item \code{r_squared} : Coefficient of determination.
+  \item \code{data} : A tibble with class \code{"cdf_estimation"} returned from \code{\link{estimate_cdf}}.
+  \item \code{distribution} : Specified distribution.
+}
+
+If more than one method was specified in \code{\link{estimate_cdf}},
+  the resulting output is a list with class \code{"model_estimation_list"}.
+  In this case each list element has classes \code{"rank_regression"} and
   \code{"model_estimation"} and the items listed above, are included.
 }
 \description{

--- a/man/rank_regression.default.Rd
+++ b/man/rank_regression.default.Rd
@@ -35,29 +35,31 @@ a right censored observation (= 0) or a failure (= 1).}
 }
 \value{
 Returns a list with the classes \code{"rank_regression"} and
-  \code{"model_estimation"} containing the following elements:
-  \itemize{
-    \item \code{coefficients} : If \code{distribution} is \code{"weibull"}, the
-      estimated scale (\eqn{\eta}) and shape (\eqn{\beta}) parameters are provided
-      (and additionally the threshold parameter \eqn{\gamma} if \code{distribution}
-      is \code{"weibull3"}). For any other distribution, \code{coefficients} is
-      identical to \code{loc_sc_params}.
-    \item \code{confint} : Only included if \code{distribution} is \code{"weibull"}
-      or \code{"weibull3"}. Approximated confidence intervals for \eqn{\eta} and
-      \eqn{\beta} (and \eqn{\gamma} if \code{distribution} is \code{"weibull3"}).
-    \item \code{loc_sc_params} : Estimated (log-)location-scale parameters.
-      Threshold parameter is included if \code{distribution} is \code{"weibull3"},
-      \code{"lognormal3"} or \code{"loglogistic3"}.
-    \item \code{loc_sc_confint} : Confidence intervals for (log-)location-scale
-      parameters. If distribution is \code{"lognormal3"} or \code{"loglogistic3"}
-      a confidence interval for the threshold parameter is not computed.
-    \item \code{loc_sc_varcov} : Provided, if \code{distribution} is not
-      \code{"weibull"} or \code{"weibull3"}. Estimated heteroscedasticity-consistent
-      variance-covariance matrix for the (log-)location-scale parameters.
-    \item \code{r_squared} : Coefficient of determination.
-    \item \code{data} : A tibble with columns \code{x}, \code{status} and \code{prob}.
-    \item \code{distribution} : Specified distribution.
-  }
+\code{"model_estimation"} containing the following elements:
+\itemize{
+  \item \code{coefficients} : A named vector of estimated coefficients
+    (parameters of the assumed distribution). \strong{Note}: The parameters
+    are given in location-scale-parameterization. If \code{distribution} is
+    \code{"weibull"} this is not the parameterization used in
+    \code{\link[stats:Weibull]{stats::Weibull}}. The parameters of the
+    shape-scale-parameterization are given under
+    \code{shape_scale_coefficients}.
+  \item \code{shape_scale_coefficients} : Only included if
+    \code{distribution} is \code{"weibull"} or \code{"weibull3"}. See
+    \code{coefficients}.
+  \item \code{confint} : Only included if \code{distribution} is \code{"weibull"}
+    or \code{"weibull3"}. Approximated confidence intervals for \eqn{\eta} and
+    \eqn{\beta} (and \eqn{\gamma} if \code{distribution} is \code{"weibull3"}).
+  \item \code{loc_sc_confint} : Confidence intervals for (log-)location-scale
+    parameters. If distribution is \code{"lognormal3"} or \code{"loglogistic3"}
+    a confidence interval for the threshold parameter is not computed.
+  \item \code{loc_sc_varcov} : Provided, if \code{distribution} is not
+    \code{"weibull"} or \code{"weibull3"}. Estimated heteroscedasticity-consistent
+    variance-covariance matrix for the (log-)location-scale parameters.
+  \item \code{r_squared} : Coefficient of determination.
+  \item \code{data} : A tibble with columns \code{x}, \code{status} and \code{prob}.
+  \item \code{distribution} : Specified distribution.
+}
 }
 \description{
 This function fits an \strong{x on y} regression to a linearized two- or

--- a/tests/testthat/_snaps/mixture_identification.md
+++ b/tests/testthat/_snaps/mixture_identification.md
@@ -3,20 +3,20 @@
     $mod_1
     Rank Regression
     Coefficients:
-          eta       beta  
-    1002.5182     0.6384  
+       mu  sigma  
+    6.910  1.566  
     
     $mod_2
     Rank Regression
     Coefficients:
-        eta     beta  
-    370.746    1.545  
+        mu   sigma  
+    5.9155  0.6474  
     
     $mod_3
     Rank Regression
     Coefficients:
-        eta     beta  
-    310.647    3.902  
+        mu   sigma  
+    5.7387  0.2563  
     
     attr(,"class")
     [1] "mixmod_regression" "list"             
@@ -25,13 +25,13 @@
 
     Maximum Likelihood Estimation
     Coefficients:
-        eta     beta  
-    330.342    4.805  
+        mu   sigma  
+    5.8001  0.2081  
 
 ---
 
     Maximum Likelihood Estimation
     Coefficients:
-        eta     beta  
-    69.6665   0.8234  
+       mu  sigma  
+    4.244  1.214  
 

--- a/tests/testthat/_snaps/ml_estimation.md
+++ b/tests/testthat/_snaps/ml_estimation.md
@@ -31,8 +31,8 @@
 
     Maximum Likelihood Estimation
     Coefficients:
-          eta       beta  
-    99325.410      1.913  
+         mu    sigma  
+    11.5062   0.5227  
 
 ---
 
@@ -50,6 +50,6 @@
 
     Maximum Likelihood Estimation
     Coefficients:
-          eta       beta      gamma  
-    9.933e+04  1.913e+00  1.205e-05  
+           mu      sigma      gamma  
+    1.151e+01  5.227e-01  1.205e-05  
 

--- a/tests/testthat/_snaps/plot_helpers.md
+++ b/tests/testthat/_snaps/plot_helpers.md
@@ -65,37 +65,37 @@
 # plot_prob_helper remains stable
 
     CDF estimation for methods 'johnson', 'kaplan':
-    # A tibble: 134 x 8
-       id        x status  rank    prob method      q group
-       <chr> <dbl>  <dbl> <dbl>   <dbl> <chr>   <dbl> <chr>
-     1 ID72     94      1     1 0.00967 johnson -4.63 null 
-     2 ID72     94      1    NA 0.0139  kaplan  -4.27 null 
-     3 ID71     96      1     2 0.0235  johnson -3.74 null 
-     4 ID71     96      1    NA 0.0278  kaplan  -3.57 null 
-     5 ID69     99      1     4 0.0511  johnson -2.95 null 
-     6 ID70     99      1     4 0.0511  johnson -2.95 null 
-     7 ID69     99      1    NA 0.0556  kaplan  -2.86 null 
-     8 ID70     99      1    NA 0.0556  kaplan  -2.86 null 
-     9 ID68    104      1     5 0.0649  johnson -2.70 null 
-    10 ID68    104      1    NA 0.0694  kaplan  -2.63 null 
+    # A tibble: 134 x 7
+       id        x status  rank    prob method      q
+       <chr> <dbl>  <dbl> <dbl>   <dbl> <chr>   <dbl>
+     1 ID72     94      1     1 0.00967 johnson -4.63
+     2 ID72     94      1    NA 0.0139  kaplan  -4.27
+     3 ID71     96      1     2 0.0235  johnson -3.74
+     4 ID71     96      1    NA 0.0278  kaplan  -3.57
+     5 ID69     99      1     4 0.0511  johnson -2.95
+     6 ID70     99      1     4 0.0511  johnson -2.95
+     7 ID69     99      1    NA 0.0556  kaplan  -2.86
+     8 ID70     99      1    NA 0.0556  kaplan  -2.86
+     9 ID68    104      1     5 0.0649  johnson -2.70
+    10 ID68    104      1    NA 0.0694  kaplan  -2.63
     # ... with 124 more rows
 
 ---
 
     CDF estimation for methods 'johnson', 'kaplan':
-    # A tibble: 134 x 8
-       id        x status  rank    prob method      q group
-       <chr> <dbl>  <dbl> <dbl>   <dbl> <chr>   <dbl> <chr>
-     1 ID72     94      1     1 0.00967 johnson -2.34 null 
-     2 ID72     94      1    NA 0.0139  kaplan  -2.20 null 
-     3 ID71     96      1     2 0.0235  johnson -1.99 null 
-     4 ID71     96      1    NA 0.0278  kaplan  -1.91 null 
-     5 ID69     99      1     4 0.0511  johnson -1.63 null 
-     6 ID70     99      1     4 0.0511  johnson -1.63 null 
-     7 ID69     99      1    NA 0.0556  kaplan  -1.59 null 
-     8 ID70     99      1    NA 0.0556  kaplan  -1.59 null 
-     9 ID68    104      1     5 0.0649  johnson -1.51 null 
-    10 ID68    104      1    NA 0.0694  kaplan  -1.48 null 
+    # A tibble: 134 x 7
+       id        x status  rank    prob method      q
+       <chr> <dbl>  <dbl> <dbl>   <dbl> <chr>   <dbl>
+     1 ID72     94      1     1 0.00967 johnson -2.34
+     2 ID72     94      1    NA 0.0139  kaplan  -2.20
+     3 ID71     96      1     2 0.0235  johnson -1.99
+     4 ID71     96      1    NA 0.0278  kaplan  -1.91
+     5 ID69     99      1     4 0.0511  johnson -1.63
+     6 ID70     99      1     4 0.0511  johnson -1.63
+     7 ID69     99      1    NA 0.0556  kaplan  -1.59
+     8 ID70     99      1    NA 0.0556  kaplan  -1.59
+     9 ID68    104      1     5 0.0649  johnson -1.51
+    10 ID68    104      1    NA 0.0694  kaplan  -1.48
     # ... with 124 more rows
 
 # plot_mod_helper remains stable

--- a/tests/testthat/_snaps/plot_helpers.md
+++ b/tests/testthat/_snaps/plot_helpers.md
@@ -101,18 +101,18 @@
 # plot_mod_helper remains stable
 
     # A tibble: 100 x 7
-         x_p    y_p param_val param_label method   group     q
-       <dbl>  <dbl> <list>    <list>      <chr>    <chr> <dbl>
-     1 6700  0.0183 <chr [3]> <chr [3]>   mod_null _null -3.99
-     2 6798. 0.0190 <chr [3]> <chr [3]>   mod_null _null -3.95
-     3 6897. 0.0198 <chr [3]> <chr [3]>   mod_null _null -3.91
-     4 6997. 0.0206 <chr [3]> <chr [3]>   mod_null _null -3.87
-     5 7100. 0.0214 <chr [3]> <chr [3]>   mod_null _null -3.83
-     6 7203. 0.0223 <chr [3]> <chr [3]>   mod_null _null -3.79
-     7 7308. 0.0232 <chr [3]> <chr [3]>   mod_null _null -3.75
-     8 7415. 0.0241 <chr [3]> <chr [3]>   mod_null _null -3.71
-     9 7523. 0.0251 <chr [3]> <chr [3]>   mod_null _null -3.67
-    10 7633. 0.0261 <chr [3]> <chr [3]>   mod_null _null -3.63
+         x_p    y_p param_val param_label method group     q
+       <dbl>  <dbl> <list>    <list>      <chr>  <chr> <dbl>
+     1 6700  0.0183 <chr [3]> <chr [3]>   <NA>   <NA>  -3.99
+     2 6798. 0.0190 <chr [3]> <chr [3]>   <NA>   <NA>  -3.95
+     3 6897. 0.0198 <chr [3]> <chr [3]>   <NA>   <NA>  -3.91
+     4 6997. 0.0206 <chr [3]> <chr [3]>   <NA>   <NA>  -3.87
+     5 7100. 0.0214 <chr [3]> <chr [3]>   <NA>   <NA>  -3.83
+     6 7203. 0.0223 <chr [3]> <chr [3]>   <NA>   <NA>  -3.79
+     7 7308. 0.0232 <chr [3]> <chr [3]>   <NA>   <NA>  -3.75
+     8 7415. 0.0241 <chr [3]> <chr [3]>   <NA>   <NA>  -3.71
+     9 7523. 0.0251 <chr [3]> <chr [3]>   <NA>   <NA>  -3.67
+    10 7633. 0.0261 <chr [3]> <chr [3]>   <NA>   <NA>  -3.63
     # ... with 90 more rows
 
 # plot_mod_mix_helper remains stable

--- a/tests/testthat/_snaps/rank_regression.md
+++ b/tests/testthat/_snaps/rank_regression.md
@@ -29,8 +29,8 @@
 
     Rank Regression
     Coefficients:
-          eta       beta  
-    1.048e+05  1.476e+00  
+         mu    sigma  
+    11.5594   0.6774  
 
 ---
 
@@ -45,6 +45,6 @@
 
     Rank Regression
     Coefficients:
-       eta    beta   gamma  
-    96.749   1.525  88.428  
+         mu    sigma    gamma  
+     4.5721   0.6556  88.4275  
 

--- a/tests/testthat/test-confidence_intervals.R
+++ b/tests/testthat/test-confidence_intervals.R
@@ -16,7 +16,7 @@ test_that("confint_betabinom remains stable", {
 
   tbl_john <- estimate_cdf(tbl, "johnson")
 
-  mrr <- rank_regression(
+  rr <- rank_regression(
     tbl_john,
     distribution = "weibull",
     conf_level = .95
@@ -25,7 +25,7 @@ test_that("confint_betabinom remains stable", {
   conf_betabin <- confint_betabinom(
     x = tbl_john$x,
     status = tbl_john$status,
-    loc_sc_params = mrr$loc_sc_params,
+    dist_params = rr$coefficients,
     distribution = "weibull",
     bounds = "two_sided",
     conf_level = 0.95,
@@ -46,7 +46,7 @@ test_that("confint_betabinom remains stable", {
 
   tbl_john_2 <- estimate_cdf(tbl_2, "johnson")
 
-  mrr_weib3 <- rank_regression(
+  rr_weib3 <- rank_regression(
     x = tbl_john_2$x,
     y = tbl_john_2$prob,
     status = tbl_john_2$status,
@@ -57,7 +57,7 @@ test_that("confint_betabinom remains stable", {
   conf_betabin_weib3 <- confint_betabinom(
     x = tbl_john_2$x,
     status = tbl_john_2$status,
-    loc_sc_params = mrr_weib3$loc_sc_params,
+    dist_params = rr_weib3$coefficients,
     distribution = "weibull3",
     bounds = "two_sided",
     conf_level = 0.95,
@@ -69,7 +69,7 @@ test_that("confint_betabinom remains stable", {
   conf_betabin_x <- confint_betabinom(
     x = tbl_john$x,
     status = tbl_john$status,
-    loc_sc_params = mrr$loc_sc_params,
+    dist_params = rr$coefficients,
     distribution = "weibull",
     bounds = "two_sided",
     conf_level = 0.95,
@@ -91,7 +91,7 @@ test_that("confint_fisher remains stable", {
   conf_fish <- confint_fisher(
     x = tbl_john$x,
     status = tbl_john$status,
-    loc_sc_params = mle$loc_sc_params,
+    dist_params = mle$coefficients,
     loc_sc_varcov = mle$loc_sc_varcov,
     distribution = "weibull",
     bounds = "two_sided",
@@ -104,7 +104,7 @@ test_that("confint_fisher remains stable", {
   conf_fish_x <- confint_fisher(
     x = tbl_john$x,
     status = tbl_john$status,
-    loc_sc_params = mle$loc_sc_params,
+    dist_params = mle$coefficients,
     loc_sc_varcov = mle$loc_sc_varcov,
     distribution = "weibull",
     bounds = "two_sided",
@@ -127,7 +127,7 @@ test_that("delta_method remains stable", {
   )
 
   delta_prob <- sapply(obs, delta_method,
-                       loc_sc_params = mle$loc_sc_params,
+                       dist_params = mle$coefficients,
                        loc_sc_varcov = mle$loc_sc_varcov,
                        distribution = "weibull",
                        direction = "y"
@@ -139,7 +139,7 @@ test_that("delta_method remains stable", {
 test_that("predict_quantile remains stable", {
   quants <- predict_quantile(
     p = c(0.01, 0.1, 0.5),
-    loc_sc_params = c(5, 0.5),
+    dist_params = c(5, 0.5),
     distribution = "weibull"
   )
 
@@ -147,7 +147,7 @@ test_that("predict_quantile remains stable", {
 
   quants_weib3 <- predict_quantile(
     p = c(0.01, 0.1, 0.5),
-    loc_sc_params = c(5, 0.5, 10),
+    dist_params = c(5, 0.5, 10),
     distribution = "weibull3"
   )
 
@@ -157,7 +157,7 @@ test_that("predict_quantile remains stable", {
 test_that("predict_prob remains stable", {
   probs <- predict_prob(
     q = c(15, 48, 124),
-    loc_sc_params = c(5, 0.5),
+    dist_params = c(5, 0.5),
     distribution = "weibull"
   )
 
@@ -165,7 +165,7 @@ test_that("predict_prob remains stable", {
 
   probs_weib3 <- predict_prob(
     q = c(25, 58, 134),
-    loc_sc_params = c(5, 0.5, 10),
+    dist_params = c(5, 0.5, 10),
     distribution = "weibull3"
   )
 

--- a/tests/testthat/test-ml_estimation.R
+++ b/tests/testthat/test-ml_estimation.R
@@ -25,7 +25,7 @@ test_that("ml_estimation remains stable", {
     conf_level = 0.90
   )
 
-  expect_snapshot_output(mle$loc_sc_params)
+  expect_snapshot_output(mle$coefficients)
   expect_snapshot_output(mle$loc_sc_varcov)
   expect_snapshot_output(mle)
 
@@ -41,7 +41,7 @@ test_that("ml_estimation remains stable", {
     conf_level = 0.95
   )
 
-  expect_snapshot_output(mle_weib3$loc_sc_params)
+  expect_snapshot_output(mle_weib3$coefficients)
   expect_snapshot_output(mle_weib3$loc_sc_varcov)
   expect_snapshot_output(mle_weib3)
 })

--- a/tests/testthat/test-plot_helpers.R
+++ b/tests/testthat/test-plot_helpers.R
@@ -52,11 +52,11 @@ test_that("plot_mod_helper remains stable", {
 
   cdf <- estimate_cdf(data, "johnson")
 
-  mrr <- rank_regression(cdf)
+  rr <- rank_regression(cdf)
 
   helper <- plot_mod_helper(
-    x = range(mrr$data$x),
-    loc_sc_params = mrr$loc_sc_params,
+    x = range(rr$data$x),
+    dist_params = rr$coefficients,
     distribution = "weibull"
   )
 
@@ -69,10 +69,10 @@ test_that("plot_mod_mix_helper remains stable", {
 
   cdf <- estimate_cdf(data, "johnson")
 
-  mrr <- rank_regression(cdf)
+  rr <- rank_regression(cdf)
 
   helper <- plot_mod_mix_helper(
-    model_estimation = mrr,
+    model_estimation = rr,
     method = "johnson",
     group = "group"
   )
@@ -85,8 +85,8 @@ test_that("plot_pop_helper remains stable", {
   suppressWarnings(library(tibble))
   set.seed(1)
   x <- rweibull(n = 100, shape = 1, scale = 20000)
-  loc_sc_params_tbl <- tibble(loc = log(20000), sc = 1, thres = NA)
+  dist_params_tbl <- tibble(loc = log(20000), sc = 1, thres = NA)
   expect_snapshot_output(
-    plot_pop_helper(x, loc_sc_params_tbl, "weibull")
+    plot_pop_helper(x, dist_params_tbl, "weibull")
   )
 })

--- a/tests/testthat/test-rank_regression.R
+++ b/tests/testthat/test-rank_regression.R
@@ -24,15 +24,15 @@ test_that("rank_regression remains stable", {
 
   tbl_john <- estimate_cdf(data, "johnson")
 
-  mrr <- rank_regression(
+  rr <- rank_regression(
     tbl_john,
     distribution = "weibull",
     conf_level = .90
   )
 
-  expect_snapshot_output(mrr$loc_sc_params)
-  expect_snapshot_output(mrr$r_squared)
-  expect_snapshot_output(mrr)
+  expect_snapshot_output(rr$coefficients)
+  expect_snapshot_output(rr$r_squared)
+  expect_snapshot_output(rr)
 
   cycles   <- c(300, 300, 300, 300, 300, 291, 274, 271, 269, 257, 256, 227, 226,
                 224, 213, 211, 205, 203, 197, 196, 190, 189, 188, 187, 184, 180,
@@ -45,15 +45,15 @@ test_that("rank_regression remains stable", {
   data <- reliability_data(x = cycles, status = status)
 
   tbl_john <- estimate_cdf(data, "johnson")
-  mrr <- rank_regression(
+  rr <- rank_regression(
     tbl_john,
     distribution = "weibull3",
     conf_level = .90
   )
 
-  expect_snapshot_output(mrr$loc_sc_params)
-  expect_snapshot_output(mrr$r_squared)
-  expect_snapshot_output(mrr)
+  expect_snapshot_output(rr$coefficients)
+  expect_snapshot_output(rr$r_squared)
+  expect_snapshot_output(rr)
 })
 
 test_that("rank_regression supports multiple methods", {
@@ -63,11 +63,11 @@ test_that("rank_regression supports multiple methods", {
 
   cdf_tbl <- estimate_cdf(data, methods)
 
-  mrr <- rank_regression.cdf_estimation(
+  rr <- rank_regression.cdf_estimation(
     x = cdf_tbl,
     distribution = "weibull"
   )
 
-  expect_equal(length(mrr), 3)
-  expect_true(all(methods %in% names(mrr)))
+  expect_equal(length(rr), 3)
+  expect_true(all(methods %in% names(rr)))
 })

--- a/vignettes/Life_Data_Analysis_Part_I.md
+++ b/vignettes/Life_Data_Analysis_Part_I.md
@@ -2,7 +2,7 @@
 title: "Life Data Analysis Part I - Estimation of Failure Probabilities"
 subtitle: "A Non-parametric Approach"
 author: "Tim-Gunnar Hensel"
-date: "2020-12-15"
+date: "2020-12-16"
 output:
   rmarkdown::html_vignette:
     fig_height: 6
@@ -28,10 +28,14 @@ In order to obtain an estimate of the cumulative failure probability for each ob
 
 But rank distributions are systematically skewed distributions and thus the median value instead of the expected value $E\left[F\left(t_i\right)\right] = \frac{i}{n + 1}$ is used for estimation [^note1]. This skewness is visualized in _Figure 1_. 
 
+[^note1]: Kapur, K. C.; Lamberson, L. R.: _Reliability in Engineering Design_, 
+          _New York: Wiley_, 1977, pp. 297-301  
+
 
 ```r
 library(tidyverse) # using dplyr manipulation functions and ggplot2
 #> Warning: Paket 'tibble' wurde unter R Version 4.0.3 erstellt
+#> Warning: Paket 'dplyr' wurde unter R Version 4.0.3 erstellt
 
 x <- seq(0, 1, length.out = 100) # CDF
 n <- 10 # sample size
@@ -50,9 +54,6 @@ densplot
 ```
 
 ![Figure 1: Densities for different ranks i in samples of size n = 10.](figure/rank densities-1.png)
-
-[^note1]: Kapur, K. C.; Lamberson, L. R.: _Reliability in Engineering Design_, 
-          _New York: Wiley_, 1977, pp. 297-301  
 
 ### Failure Probability Estimation  
 


### PR DESCRIPTION
- no method argument was added to default methods
- restored color scheme for one method case (blue for prob, red for prob and conf)
- fixed match.arg in confint_betabinom.model_estimation
- estimate_cdf.default supports only one method instead of multiple methods. This is for consistency with the other default methods