### PR TITLE
Closes #193

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 ## Breaking Changes
 * `confint_betabinom()` and `confint_fisher()`: Removed constant features `distribution`, `bounds` and `direction` from the tibble output and added them as attributes instead.
 * `plot_prob.wt_model()`: Removed dysfunctional argument `distribution`. The distribution is inferred using the model `x`.
+* `mcs_mileage()`: Changed name of output column `mileage` to `x` (in accordance with `reliability_data()`).
+* `mcs_delay()`: Changed name of output column `time` to `x` (in accordance with `reliability_data()`). 
 
 ## New Features
 * `confint_betabinom()`: Methods `"kaplan"` and `"nelson"` of `estimate_cdf()` can be used for beta-binomial confidence bounds. 
@@ -12,6 +14,7 @@
 * Fixed bug in `plot_conf()`: `plot_method = "ggplot2"` and exactly one method in `estimate_cdf()` resulted in an error (#182).
 * Fixed bug in `reliability_data()`: Using `!!` syntax with arguments `x` and `status` resulted in an error.
 * `estimate_cdf()` preserves additional columns, that were returned from `reliability_data(..., .keep_all = TRUE)`.
+* Improved `print.wt_reliability_data()`.
 
 ## Documentation improvements
 * `plot_prob()`: Better work out the distinction between `plot_prob.wt_cdf_estimation()` and `plot_prob.wt_model()`. The former is applied to a CDF estimation whereas the latter is applied to a mixture model.

--- a/R/delay_distributions.R
+++ b/R/delay_distributions.R
@@ -232,7 +232,7 @@ dist_delay <- function(date_1,
 #'           and the corresponding values of the earlier dates are used.
 #'         \item \code{date_2} : Later dates. In the case of a list with length greater
 #'           than 1, the routine described above is used.
-#'         \item \code{time} : Adjusted operating times for incomplete observations
+#'         \item \code{x} : Adjusted operating times for incomplete observations
 #'           and input operating times for the complete observations.
 #'         \item \code{status} (\strong{optional}) :
 #'           \itemize{
@@ -418,10 +418,10 @@ mcs_delay <- function(date_1,
   names(par_list) <- par_list_names
 
   if (purrr::is_null(status)) {
-    names(data_list) <- c(data_list_names, "time", "id")
+    names(data_list) <- c(data_list_names, "x", "id")
     class_assign <- "wt_mcs_data"
   } else {
-    names(data_list) <- c(data_list_names, "time", "status", "id")
+    names(data_list) <- c(data_list_names, "x", "status", "id")
     class_assign <- c("wt_mcs_data", "wt_reliability_data")
   }
 

--- a/R/mileage_distribution.R
+++ b/R/mileage_distribution.R
@@ -173,7 +173,6 @@ dist_mileage <- function(mileage,
 #'                 3500.25 km * (200 d / 365 d) = 1917.945 km}
 #'
 #' @inheritParams dist_mileage
-#'
 #' @param status Optional argument. If used it has to be a vector of binary data
 #'   (0 or 1) indicating whether unit i is a right censored observation (= 0) or
 #'   a failure (= 1). The effect of status on the return is described in 'Value'.
@@ -194,7 +193,7 @@ dist_mileage <- function(mileage,
 #'
 #'       The tibble contains the following columns:
 #'       \itemize{
-#'         \item \code{mileage} : Simulated distances for unknown \code{mileage} and
+#'         \item \code{x} : Simulated distances for unknown \code{mileage} and
 #'           input distances for known \code{mileage}.
 #'         \item \code{time} : Input operating times.
 #'         \item \code{status} (\strong{optional}) :
@@ -320,7 +319,7 @@ mcs_mileage <- function(mileage,
   # Defining data_tbl with class "wt_mcs_data" and/or "wt_reliability_data":
   if (purrr::is_null(status)) {
     data_tbl <- tibble::tibble(
-      mileage = mileage,
+      x = mileage,
       time = time,
       id = id
     )
@@ -333,7 +332,7 @@ mcs_mileage <- function(mileage,
     }
 
     data_tbl <- tibble::tibble(
-      mileage = mileage,
+      x = mileage,
       time = time,
       status = status,
       id = id

--- a/R/mixture_identification.R
+++ b/R/mixture_identification.R
@@ -651,7 +651,7 @@ mixmod_em_ <- function(data,
                        drop_id
 ) {
 
-  x <- get_characteristic(data)
+  x <- data$x
   status <- data$status
 
   # Providing initial random a-posteriors (see references, blog post Mr. Gelissen):

--- a/R/ml_estimation.R
+++ b/R/ml_estimation.R
@@ -159,8 +159,7 @@ ml_estimation_ <- function(data,
                            conf_level
 ) {
 
-  x <- if (inherits(data, "wt_reliability_data")) get_characteristic(data) else
-    data$x
+  x <- data$x
   status <- data$status
   id <- data$id
 

--- a/R/probability_estimators.R
+++ b/R/probability_estimators.R
@@ -325,7 +325,6 @@ mr_method_ <- function(data,
   }
 
   tbl_in <- data %>%
-    dplyr::rename(x = attr(data, "characteristic")) %>%
     # Remove additional classes
     tibble::as_tibble()
 
@@ -436,7 +435,6 @@ johnson_method <- function(x,
 johnson_method_ <- function(data) {
 
   tbl_in <- data %>%
-    dplyr::rename(x = attr(data, "characteristic")) %>%
     # Remove additional classes
     tibble::as_tibble()
 
@@ -573,7 +571,6 @@ kaplan_method_ <- function(data) {
   }
 
   tbl_in <- data %>%
-    dplyr::rename(x = attr(data, "characteristic")) %>%
     # Remove additional classes
     tibble::as_tibble()
 
@@ -701,7 +698,6 @@ nelson_method_ <- function(data) {
   }
 
   tbl_in <- data %>%
-    dplyr::rename(x = attr(data, "characteristic")) %>%
     # Remove additional classes
     tibble::as_tibble()
 

--- a/R/reliability_data.R
+++ b/R/reliability_data.R
@@ -1,12 +1,12 @@
 #' Reliability Data
 #'
 #' @description
-#' Create consistent reliability data based on an existing \code{data.frame}
+#' Create consistent reliability data based on an existing `data.frame`
 #' (preferred) or on multiple equal length vectors.
 #'
-#' @param data Either \code{NULL} or a \code{data.frame}. If data is \code{NULL},
-#' \code{x}, \code{status} and \code{id} must be vectors containing
-#' the data. Otherwise \code{x}, \code{status} and \code{id} can be either column
+#' @param data Either `NULL` or a `data.frame`. If data is `NULL`,
+#' `x`, `status` and `id` must be vectors containing
+#' the data. Otherwise `x`, `status` and `id` can be either column
 #' names or column positions.
 #' @param x Lifetime data, that means any characteristic influencing the reliability
 #' of a product, e.g. operating time (days/months in service), mileage (km, miles),
@@ -14,17 +14,20 @@
 #' @param status Binary data (0 or 1) indicating whether a unit is a right
 #' censored observation (= 0) or a failure (= 1).
 #' @param id Identification of every unit.
-#' @param .keep_all If \code{TRUE} keep remaining variables in \code{data}.
+#' @param .keep_all If `TRUE` keep remaining variables in `data`.
 #'
-#' @return A tibble with class \code{wt_reliability_data} containing the following
-#' columns (if \code{.keep_all = FALSE}):
-#' \itemize{
-#'   \item \code{x} : Lifetime characteristic.
-#'   \item \code{status} : Binary data (0 or 1) indicating whether a unit is a right
+#' @return A tibble with class `wt_reliability_data` containing the following
+#' columns (if `.keep_all = FALSE`):
+#'
+#' * `x` : Lifetime characteristic.
+#' * `status` : Binary data (0 or 1) indicating whether a unit is a right
 #'     censored observation (= 0) or a failure (= 1).
-#'   \item \code{id} : Identification for every unit.
-#' }
-#' If \code{.keep_all = TRUE}, the remaining columns of \code{data} are also preserved.
+#' * `id` : Identification for every unit.
+#'
+#' If `.keep_all = TRUE`, the remaining columns of `data` are also preserved.
+#'
+#' If `!is.null(data)` the attribute `characteristic` holds the name of the
+#' characteristic described by `x`. Otherwise it is set to `"x"`.
 #'
 #'
 #' @examples
@@ -66,6 +69,7 @@
 #'   id = id
 #' )
 #'
+#' @md
 #' @export
 reliability_data <- function(data = NULL,
                              x,
@@ -89,6 +93,8 @@ reliability_data <- function(data = NULL,
     }
 
     tbl <- tibble::tibble(x = x, status = status, id = id)
+
+    characteristic <- "x"
   } else {
     # Data based approach -----------------------------------------------------
     if (!is_characteristic(dplyr::select(data, x = {{x}})[[1]])) {
@@ -97,6 +103,15 @@ reliability_data <- function(data = NULL,
 
     if (!is_status(dplyr::select(data, status = {{status}})[[1]])) {
       stop("'status' must be numeric with elements 0 or 1!")
+    }
+
+    x_def <- dplyr::enexpr(x)
+    characteristic <- if (is.numeric(x_def)) {
+      # Column index
+      names(data)[x_def]
+    } else {
+      # Column name
+      as.character(x_def)
     }
 
     data <- tibble::as_tibble(data)
@@ -116,7 +131,7 @@ reliability_data <- function(data = NULL,
 
   class(tbl) <- c("wt_reliability_data", class(tbl))
   # Mark column x as characteristic
-  attr(tbl, "characteristic") <- "x"
+  attr(tbl, "characteristic") <- characteristic
 
   tbl
 }
@@ -129,7 +144,7 @@ print.wt_reliability_data <- function(x, ...) {
     cat("Reliability Data:\n")
   } else {
     cat(
-      "Reliability data with characteristic '",
+      "Reliability Data with characteristic x: '",
       attr(x, "characteristic"),
       "':\n",
       sep = ""
@@ -148,11 +163,4 @@ is_characteristic <- function(x) {
 
 is_status <- function(x) {
   is.numeric(x) && all(x %in% c(0, 1))
-}
-
-
-
-get_characteristic <- function(x) {
-  # x is reliability_data
-  x[[attr(x, "characteristic")]]
 }

--- a/docs/articles/Life_Data_Analysis_Part_I.html
+++ b/docs/articles/Life_Data_Analysis_Part_I.html
@@ -93,7 +93,7 @@
                         <h4 class="author">Tim-Gunnar Hensel</h4>
                         <h4 class="author">David Barkemeyer</h4>
             
-            <h4 class="date">2021-01-28</h4>
+            <h4 class="date">2021-02-01</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/Tim-TU/weibulltools/blob/master/vignettes/Life_Data_Analysis_Part_I.Rmd"><code>vignettes/Life_Data_Analysis_Part_I.Rmd</code></a></small>
       <div class="hidden name"><code>Life_Data_Analysis_Part_I.Rmd</code></div>

--- a/docs/articles/Life_Data_Analysis_Part_II.html
+++ b/docs/articles/Life_Data_Analysis_Part_II.html
@@ -93,7 +93,7 @@
                         <h4 class="author">Tim-Gunnar Hensel</h4>
                         <h4 class="author">David Barkemeyer</h4>
             
-            <h4 class="date">2021-01-28</h4>
+            <h4 class="date">2021-02-01</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/Tim-TU/weibulltools/blob/master/vignettes/Life_Data_Analysis_Part_II.Rmd"><code>vignettes/Life_Data_Analysis_Part_II.Rmd</code></a></small>
       <div class="hidden name"><code>Life_Data_Analysis_Part_II.Rmd</code></div>

--- a/docs/articles/Life_Data_Analysis_Part_III.html
+++ b/docs/articles/Life_Data_Analysis_Part_III.html
@@ -93,7 +93,7 @@
                         <h4 class="author">Tim-Gunnar Hensel</h4>
                         <h4 class="author">David Barkemeyer</h4>
             
-            <h4 class="date">2021-01-28</h4>
+            <h4 class="date">2021-02-01</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/Tim-TU/weibulltools/blob/master/vignettes/Life_Data_Analysis_Part_III.Rmd"><code>vignettes/Life_Data_Analysis_Part_III.Rmd</code></a></small>
       <div class="hidden name"><code>Life_Data_Analysis_Part_III.Rmd</code></div>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -144,6 +144,10 @@
 <code><a href="../reference/confint_betabinom.html">confint_betabinom()</a></code> and <code><a href="../reference/confint_fisher.html">confint_fisher()</a></code>: Removed constant features <code>distribution</code>, <code>bounds</code> and <code>direction</code> from the tibble output and added them as attributes instead.</li>
 <li>
 <code><a href="../reference/plot_prob.html">plot_prob.wt_model()</a></code>: Removed dysfunctional argument <code>distribution</code>. The distribution is inferred using the model <code>x</code>.</li>
+<li>
+<code><a href="../reference/mcs_mileage.html">mcs_mileage()</a></code>: Changed name of output column <code>mileage</code> to <code>x</code> (in accordance with <code><a href="../reference/reliability_data.html">reliability_data()</a></code>).</li>
+<li>
+<code><a href="../reference/mcs_delay.html">mcs_delay()</a></code>: Changed name of output column <code>time</code> to <code>x</code> (in accordance with <code><a href="../reference/reliability_data.html">reliability_data()</a></code>).</li>
 </ul>
 </div>
 <div id="new-features" class="section level2">
@@ -163,6 +167,7 @@
 <li>Fixed bug in <code><a href="../reference/reliability_data.html">reliability_data()</a></code>: Using <code>!!</code> syntax with arguments <code>x</code> and <code>status</code> resulted in an error.</li>
 <li>
 <code><a href="../reference/estimate_cdf.html">estimate_cdf()</a></code> preserves additional columns, that were returned from <code><a href="../reference/reliability_data.html">reliability_data(..., .keep_all = TRUE)</a></code>.</li>
+<li>Improved <code>print.wt_reliability_data()</code>.</li>
 </ul>
 </div>
 <div id="documentation-improvements" class="section level2">

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -5,5 +5,5 @@ articles:
   Life_Data_Analysis_Part_I: Life_Data_Analysis_Part_I.html
   Life_Data_Analysis_Part_II: Life_Data_Analysis_Part_II.html
   Life_Data_Analysis_Part_III: Life_Data_Analysis_Part_III.html
-last_built: 2021-01-28T13:05Z
+last_built: 2021-02-01T16:33Z
 

--- a/docs/reference/mcs_delay.html
+++ b/docs/reference/mcs_delay.html
@@ -233,7 +233,7 @@ to the second (See 'Examples').</p></td>
           and the corresponding values of the earlier dates are used.</p></li>
 <li><p><code>date_2</code> : Later dates. In the case of a list with length greater
           than 1, the routine described above is used.</p></li>
-<li><p><code>time</code> : Adjusted operating times for incomplete observations
+<li><p><code>x</code> : Adjusted operating times for incomplete observations
           and input operating times for the complete observations.</p></li>
 <li><p><code>status</code> (<strong>optional</strong>) :</p><ul>
 <li><p>If argument <code>status = NULL</code> column <code>status</code> does

--- a/docs/reference/mcs_mileage.html
+++ b/docs/reference/mcs_mileage.html
@@ -198,7 +198,7 @@ a failure (= 1). The effect of status on the return is described in 'Value'.</p>
 <p>If <code>status = NULL</code> class is <code>wt_mcs_data</code>, which is not
       supported by <code>estimate_cdf</code> due to missing <code>status</code>.</p>
 <p>The tibble contains the following columns:</p><ul>
-<li><p><code>mileage</code> : Simulated distances for unknown <code>mileage</code> and
+<li><p><code>x</code> : Simulated distances for unknown <code>mileage</code> and
           input distances for known <code>mileage</code>.</p></li>
 <li><p><code>time</code> : Input operating times.</p></li>
 <li><p><code>status</code> (<strong>optional</strong>) :</p><ul>
@@ -292,9 +292,9 @@ distance of this vehicle is $$3500.25 km \cdot (\frac{200 d} {365 d}) = 1917.945
   x <span class='op'>=</span> <span class='va'>mcs_distances_3</span><span class='op'>$</span><span class='va'>data</span>,
   methods <span class='op'>=</span> <span class='st'>"kaplan"</span>
 <span class='op'>)</span>
-
+</div><div class='output co'>#&gt; <span class='error'>Error: </span></div><div class='input'>
 <span class='va'>plot_prob_estimation</span> <span class='op'>&lt;-</span> <span class='fu'><a href='plot_prob.html'>plot_prob</a></span><span class='op'>(</span><span class='va'>prob_estimation</span><span class='op'>)</span>
-
+</div><div class='output co'>#&gt; <span class='error'>Error in plot_prob(prob_estimation): Objekt 'prob_estimation' nicht gefunden</span></div><div class='input'>
 </div></pre>
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="pkgdown-sidebar">

--- a/docs/reference/reliability_data.html
+++ b/docs/reference/reliability_data.html
@@ -179,9 +179,13 @@ censored observation (= 0) or a failure (= 1).</p></td>
 columns (if <code>.keep_all = FALSE</code>):</p><ul>
 <li><p><code>x</code> : Lifetime characteristic.</p></li>
 <li><p><code>status</code> : Binary data (0 or 1) indicating whether a unit is a right
-    censored observation (= 0) or a failure (= 1).</p></li>
+censored observation (= 0) or a failure (= 1).</p></li>
 <li><p><code>id</code> : Identification for every unit.</p></li>
-</ul><p>If <code>.keep_all = TRUE</code>, the remaining columns of <code>data</code> are also preserved.</p>
+</ul>
+
+<p>If <code>.keep_all = TRUE</code>, the remaining columns of <code>data</code> are also preserved.</p>
+<p>If <code>!is.null(data)</code> the attribute <code>characteristic</code> holds the name of the
+characteristic described by <code>x</code>. Otherwise it is set to <code>"x"</code>.</p>
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>
     <pre class="examples"><div class='input'><span class='co'># Example 1 -  Based on an existing data.frame/tibble and column names:</span>

--- a/man/mcs_delay.Rd
+++ b/man/mcs_delay.Rd
@@ -70,7 +70,7 @@ A list containing the following elements:
           and the corresponding values of the earlier dates are used.
         \item \code{date_2} : Later dates. In the case of a list with length greater
           than 1, the routine described above is used.
-        \item \code{time} : Adjusted operating times for incomplete observations
+        \item \code{x} : Adjusted operating times for incomplete observations
           and input operating times for the complete observations.
         \item \code{status} (\strong{optional}) :
           \itemize{

--- a/man/mcs_mileage.Rd
+++ b/man/mcs_mileage.Rd
@@ -43,7 +43,7 @@ A list containing the following elements:
 
       The tibble contains the following columns:
       \itemize{
-        \item \code{mileage} : Simulated distances for unknown \code{mileage} and
+        \item \code{x} : Simulated distances for unknown \code{mileage} and
           input distances for known \code{mileage}.
         \item \code{time} : Input operating times.
         \item \code{status} (\strong{optional}) :

--- a/man/reliability_data.Rd
+++ b/man/reliability_data.Rd
@@ -27,12 +27,16 @@ censored observation (= 0) or a failure (= 1).}
 A tibble with class \code{wt_reliability_data} containing the following
 columns (if \code{.keep_all = FALSE}):
 \itemize{
-  \item \code{x} : Lifetime characteristic.
-  \item \code{status} : Binary data (0 or 1) indicating whether a unit is a right
-    censored observation (= 0) or a failure (= 1).
-  \item \code{id} : Identification for every unit.
+\item \code{x} : Lifetime characteristic.
+\item \code{status} : Binary data (0 or 1) indicating whether a unit is a right
+censored observation (= 0) or a failure (= 1).
+\item \code{id} : Identification for every unit.
 }
+
 If \code{.keep_all = TRUE}, the remaining columns of \code{data} are also preserved.
+
+If \code{!is.null(data)} the attribute \code{characteristic} holds the name of the
+characteristic described by \code{x}. Otherwise it is set to \code{"x"}.
 }
 \description{
 Create consistent reliability data based on an existing \code{data.frame}

--- a/tests/testthat/_snaps/delay_distributions.md
+++ b/tests/testthat/_snaps/delay_distributions.md
@@ -10,7 +10,7 @@
 
 # mcs_delay remains stable by defining the seed
 
-    Reliability Data with Characteristic x: 'time':
+    Reliability Data with characteristic x: 'time':
     # A tibble: 23 x 7
        date_1.1   date_1.2   date_2.1   date_2.2       x status id   
        <chr>      <chr>      <chr>      <chr>      <dbl>  <dbl> <chr>

--- a/tests/testthat/_snaps/delay_distributions.md
+++ b/tests/testthat/_snaps/delay_distributions.md
@@ -10,9 +10,9 @@
 
 # mcs_delay remains stable by defining the seed
 
-    Reliability data with characteristic 'time':
+    Reliability Data with Characteristic x: 'time':
     # A tibble: 23 x 7
-       date_1.1   date_1.2   date_2.1   date_2.2    time status id   
+       date_1.1   date_1.2   date_2.1   date_2.2       x status id   
        <chr>      <chr>      <chr>      <chr>      <dbl>  <dbl> <chr>
      1 2014-07-28 <NA>       <NA>       <NA>        969.      0 ID1  
      2 2014-02-17 2014-09-15 2014-03-29 2014-10-09 1000       1 ID2  

--- a/tests/testthat/_snaps/mileage_distribution.md
+++ b/tests/testthat/_snaps/mileage_distribution.md
@@ -12,7 +12,7 @@
 
 # mcs_mileage remains stable by defining the seed
 
-    Reliability Data with Characteristic x: 'mileage':
+    Reliability Data with characteristic x: 'mileage':
     # A tibble: 23 x 4
             x  time status id   
         <dbl> <dbl>  <dbl> <chr>

--- a/tests/testthat/_snaps/mileage_distribution.md
+++ b/tests/testthat/_snaps/mileage_distribution.md
@@ -12,20 +12,20 @@
 
 # mcs_mileage remains stable by defining the seed
 
-    Reliability data with characteristic 'mileage':
+    Reliability Data with Characteristic x: 'mileage':
     # A tibble: 23 x 4
-       mileage  time status id   
-         <dbl> <dbl>  <dbl> <chr>
-     1  11837.  1000      0 ID1  
-     2  15655   1000      1 ID2  
-     3  13629   1000      1 ID3  
-     4  18292   1000      1 ID4  
-     5  37803.  1000      0 ID5  
-     6  39924.  1000      0 ID6  
-     7  33555   1000      1 ID7  
-     8  18915.  1000      0 ID8  
-     9  21737   1000      1 ID9  
-    10  29870   1000      1 ID10 
+            x  time status id   
+        <dbl> <dbl>  <dbl> <chr>
+     1 11837.  1000      0 ID1  
+     2 15655   1000      1 ID2  
+     3 13629   1000      1 ID3  
+     4 18292   1000      1 ID4  
+     5 37803.  1000      0 ID5  
+     6 39924.  1000      0 ID6  
+     7 33555   1000      1 ID7  
+     8 18915.  1000      0 ID8  
+     9 21737   1000      1 ID9  
+    10 29870   1000      1 ID10 
     # ... with 13 more rows
 
 ---


### PR DESCRIPTION
In the data-based approach `reliability_data()` now defuses the column name from the argument x and set it as attribute `characteristic`. For example: `rel_tbl <- reliability_data(shock, distance, status)` leads to `attr(rel_tbl, "characteristic") == "distance"`.